### PR TITLE
Upload artefact on release - 1.X

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
           path: "CHANGELOG-1.X.md"
           version: ${{ github.ref_name }}
 
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.10.1
+      - name : Create Helm-package
+        run: make helm-package
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -31,3 +37,4 @@ jobs:
           draft: true
           prerelease: false
           body: ${{ steps.changelog.outputs.changes }}
+          files: out-helm/*


### PR DESCRIPTION
For RKE2, we need the archive of the helm.

Closes #623 