### PR TITLE
Fix E2E test after runner Docker upgrade

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -79,7 +79,7 @@ jobs:
       working-directory: set-up-rke-cluster
     - name: Push the Docker image
       run: |
-        make build-image image-tag image-push
+        make buildx-image image-tag image-push
         docker image prune -a -f
       env:
         REGISTRY_IMAGE: localhost:4242/csi

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ build:
 build-image:
 	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(IMAGE_TAG) .
 
+.PHONY: buildx-image
+buildx-image:
+	docker buildx build --build-arg VERSION=$(VERSION) --load -t $(IMAGE):$(IMAGE_TAG) . 
+
 .PHONY: verify
 verify:
 	./hack/verify-all


### PR DESCRIPTION
This PR is for fixing build of docker after last upgrade of runner 

See https://github.com/outscale-mdr/osc-bsu-csi-driver/actions/runs/4405177787/jobs/7783208526

⚠️ The CI will fail because we have modified the GH Action 