### PR TITLE
Fix docker e2e test after docker upgrade

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -109,7 +109,7 @@ jobs:
         OSC_ACCESS_KEY: ${{ secrets.OSC_ACCESS_KEY }}
         OSC_SECRET_KEY: ${{ secrets.OSC_SECRET_KEY }}
         OSC_REGION: ${{ secrets.OSC_REGION }}
-      run: bash -c "KC=$(base64 -w 0 set-up-rke-cluster/rke/kube_config_cluster.yml) make test-e2e-single-az"
+      run: bash -c "KC=$(base64 -w 0 set-up-rke-cluster/rke/kube_config_cluster.yml) make test-e2e-single-az-buildx"
     - name: Uninstall CSI
       run: |
         kubectl delete -f set-up-rke-cluster/addons/csi/secrets.yaml

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,9 @@ dockerlint:
 	@echo "Lint images =>  $(DOCKERFILES)"
 	$(foreach image,$(DOCKERFILES), echo "Lint  ${image} " ; docker run --rm -i hadolint/hadolint:${LINTER_VERSION} hadolint - < ${image} || exit 1 ; )
 
-.PHONY: test-e2e-single-az
-test-e2e-single-az:
-	@echo "test-e2e-single-az"
-	docker build  -t $(E2E_ENV) -f ./tests/e2e/docker/Dockerfile_e2eTest .
+.PHONY: test-e2e-single-az-run
+test-e2e-single-az-run:
+	@echo "test-e2e-single-az-run"
 	docker run --rm \
 		-v ${PWD}:/root/osc-bsu-csi-driver \
 		-e OSC_ACCESS_KEY=${OSC_ACCESS_KEY} \
@@ -86,6 +85,18 @@ test-e2e-single-az:
 		-e OSC_REGION=${OSC_REGION} \
 		-e KC="$${KC}" \
 		--name $(E2E_ENV_RUN) $(E2E_ENV) tests/e2e/docker/run_e2e_single_az.sh
+
+.PHONY: test-e2e-single-az
+test-e2e-single-az:
+	@echo "test-e2e-single-az"
+	docker build -t $(E2E_ENV) -f ./tests/e2e/docker/Dockerfile_e2eTest .
+	$(MAKE) test-e2e-single-az-run
+
+.PHONY: test-e2e-single-az-buildx
+test-e2e-single-az-buildx:
+	@echo "test-e2e-single-az"
+	docker buildx build  --load -t $(E2E_ENV) -f ./tests/e2e/docker/Dockerfile_e2eTest .
+	$(MAKE) test-e2e-single-az-run
 
 bin/mockgen: | bin
 	go get github.com/golang/mock/mockgen@latest


### PR DESCRIPTION
Previous PR (#653) did not fix all the issu. We also need to change the build of e2e tests images

See https://github.com/outscale-mdr/osc-bsu-csi-driver/actions/runs/4437418122/jobs/7787082096