### PR TITLE
Handle 39 volumes for scsi device

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,10 +1,10 @@
 # osc-bsu-csi-driver
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 A Helm chart for Outscale BSU CSI Driver
 
-**Homepage:** <https://github.com/outscale-dev/osc-bsu-csi-driver>
+**Homepage:** <https://github.com/outscale/osc-bsu-csi-driver>
 
 ## Maintainers
 
@@ -14,7 +14,7 @@ A Helm chart for Outscale BSU CSI Driver
 
 ## Source Code
 
-* <https://github.com/outscale-dev/osc-bsu-csi-driver>
+* <https://github.com/outscale/osc-bsu-csi-driver>
 
 ## Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.1
 	github.com/onsi/gomega v1.26.0
 	github.com/outscale/osc-sdk-go/v2 v2.15.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.5.0
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.1
@@ -107,6 +107,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	go.opentelemetry.io/contrib v0.20.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0 // indirect
 	go.opentelemetry.io/otel v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -400,6 +402,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -19,12 +19,12 @@ package driver
 import (
 	"context"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
-
-	"golang.org/x/sys/unix"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/outscale-dev/osc-bsu-csi-driver/pkg/cloud"
@@ -751,9 +751,29 @@ func (d *nodeService) findDevicePath(devicePath, volumeID string) (string, error
 	}
 
 	// assumption it is a scsi volume for 3DS env
-	scsiName := "scsi-0QEMU_QEMU_HARDDISK_sd" + devicePath[len(devicePath)-1:]
+	scsiName, err := findScsiName(devicePath)
+	if err != nil {
+		return "", err
+	}
+
 	klog.V(4).Infof("findDevicePath: check if scsi device for %s is %s and return the device", devicePath, scsiName)
 	return findScsiVolume(scsiName)
+}
+
+func findScsiName(devicePath string) (string, error) {
+	myreg := regexp.MustCompile(`^/dev/xvd(?P<suffix>[a-z]{1,2})$`)
+	match := myreg.FindStringSubmatch(devicePath)
+	result := make(map[string]string)
+	if myreg.MatchString(devicePath) {
+		for i, name := range myreg.SubexpNames() {
+			if i != 0 && name != "" {
+				result[name] = match[i]
+			}
+		}
+		scsiName := "scsi-0QEMU_QEMU_HARDDISK_sd" + result["suffix"]
+		return scsiName, nil
+	}
+	return "", fmt.Errorf("devicePath %s is not supported", devicePath)
 }
 
 func findScsiVolume(findName string) (device string, err error) {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/outscale-dev/osc-bsu-csi-driver/pkg/driver/internal"
 	"github.com/outscale-dev/osc-bsu-csi-driver/pkg/driver/luks"
 	"github.com/outscale-dev/osc-bsu-csi-driver/pkg/driver/mocks"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	exec "k8s.io/utils/exec"
@@ -1788,6 +1790,44 @@ func TestNodeGetInfo(t *testing.T) {
 
 			if resp.GetMaxVolumesPerNode() != tc.expMaxVolumes {
 				t.Fatalf("Expected %d max volumes per node, got %d", tc.expMaxVolumes, resp.GetMaxVolumesPerNode())
+			}
+		})
+	}
+}
+
+func TestFindScsiName(t *testing.T) {
+	findScsiNameCase := []struct {
+		name                string
+		devicePath          string
+		scsiName            string
+		expTestFindScsiName error
+	}{
+		{
+			name:                "Validate format xvdx",
+			devicePath:          "/dev/xvda",
+			scsiName:            "scsi-0QEMU_QEMU_HARDDISK_sda",
+			expTestFindScsiName: nil,
+		},
+		{
+			name:                "Validate format xvdxy",
+			devicePath:          "/dev/xvdaa",
+			scsiName:            "scsi-0QEMU_QEMU_HARDDISK_sdaa",
+			expTestFindScsiName: nil,
+		},
+		{
+			name:                "Invalide format xvdxyz",
+			devicePath:          "/dev/xvdaaa",
+			scsiName:            "scsi-0QEMU_QEMU_HARDDISK_sd",
+			expTestFindScsiName: fmt.Errorf("devicePath /dev/xvdaaa is not supported"),
+		},
+	}
+	for _, fsnc := range findScsiNameCase {
+		t.Run(fsnc.name, func(t *testing.T) {
+			scsiName, err := findScsiName(fsnc.devicePath)
+			if err != nil {
+				assert.Equal(t, fsnc.expTestFindScsiName.Error(), err.Error())
+			} else {
+				assert.Equal(t, fsnc.scsiName, scsiName)
 			}
 		})
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug
**What is this PR about? / Why do we need it?**
To be able to mount 39 volumes per node for scsi device
And to solved for example:
```
2023-05-24T04:02:26Z : Warning : FailedMount : MountVolume.MountDevice failed for volume "pvc-5b47b495-a962-47cb-9deb-4962fb6f7a3b" : rpc error: code = Internal desc = Failed to find device path /dev/xvdaa. scsi path "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_sda" not found
```
**What testing is done?** 
Unit test
