### PR TITLE
Configure https proxy + ca bundle

### DIFF
--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -101,9 +101,20 @@ spec:
               value: "{{ .Values.backoff.factor }}"
             - name: BACKOFF_STEPS
               value: "{{ .Values.backoff.steps }}"
+            {{- if .Values.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.httpsProxy }}
+            - name: NO_PROXY
+              value: {{ .Values.noProxy }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            {{- if .Values.caBundle.name }}
+            - name: ca-bundle
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            {{- end }}
           ports:
             - name: healthz
               containerPort: {{ .Values.sidecars.livenessProbeImage.port }}
@@ -279,3 +290,11 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+        {{- if .Values.caBundle.name }}
+        - name: ca-bundle
+          secret:
+            secretName: {{ .Values.caBundle.name }}
+            items:
+              - key: {{ .Values.caBundle.key }}
+                path: ca-certificates.crt
+        {{- end }}

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -188,3 +188,12 @@ credentials:
 csiDriver:
   # -- Policy of the FileSystem (see [Docs](https://kubernetes-csi.github.io/docs/support-fsgroup.html#supported-modes))
   fsGroupPolicy: File
+
+# -- HTTP proxy configuration example 
+# caBundle:
+#   name: my-ca-bundle
+#   key: my-ca-bundle.pem
+
+# httpsProxy: https://my-proxy.foo.bar
+
+noProxy: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.169.254

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -189,9 +189,13 @@ csiDriver:
   # -- Policy of the FileSystem (see [Docs](https://kubernetes-csi.github.io/docs/support-fsgroup.html#supported-modes))
   fsGroupPolicy: File
 
-# -- HTTP proxy configuration example 
-# caBundle:
-#   name: my-ca-bundle
-#   key: my-ca-bundle.pem
-# httpsProxy: https://my-proxy.foo.bar
-# noProxy: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.169.254
+caBundle:
+  # -- Secret name containing additional certificates authorities
+  name: ''
+  # -- Entry key in secret used to store additional certificates authorities
+  key: ''
+
+# -- Value used to create environment variable HTTPS_PROXY
+httpsProxy: ''
+# -- Value used to create environment variable NO_PROXY
+noProxy: ''

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -193,7 +193,5 @@ csiDriver:
 # caBundle:
 #   name: my-ca-bundle
 #   key: my-ca-bundle.pem
-
 # httpsProxy: https://my-proxy.foo.bar
-
-noProxy: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.169.254
+# noProxy: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.169.254


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

feature

**What is this PR about? / Why do we need it?**

Allow osc ccm to manipulate osc api through an https proxy when k8s cluster is not directly exposed on internet.

**What testing is done?** 

Tested with a rke2 cluster on Osc with no direct access to internet (use a squid proxy to make calls to osc api).

Mirror of the PR https://github.com/outscale/cloud-provider-osc/pull/317 for the CSI driver

