### PR TITLE
Be able to use official topology

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -534,9 +534,17 @@ func pickAvailabilityZone(requirement *csi.TopologyRequirement) string {
 		if exists {
 			return zone
 		}
+		zone, exists = topology.GetSegments()[TopologyK8sKey]
+		if exists {
+			return zone
+		}
 	}
 	for _, topology := range requirement.GetRequisite() {
 		zone, exists := topology.GetSegments()[TopologyKey]
+		if exists {
+			return zone
+		}
+		zone, exists = topology.GetSegments()[TopologyK8sKey]
 		if exists {
 			return zone
 		}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -1267,6 +1267,28 @@ func TestPickAvailabilityZone(t *testing.T) {
 			expZone: expZone,
 		},
 		{
+			name: "Pick from requisite topologyK8sKey",
+			requirement: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{TopologyK8sKey: expZone},
+					},
+				},
+			},
+			expZone: expZone,
+		},
+		{
+			name: "Pick from multi requisites",
+			requirement: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{TopologyKey: expZone, TopologyK8sKey: expZone},
+					},
+				},
+			},
+			expZone: expZone,
+		},
+		{
 			name: "Pick from empty topology",
 			requirement: &csi.TopologyRequirement{
 				Preferred: []*csi.Topology{{}},

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -41,8 +41,9 @@ const (
 )
 
 const (
-	DriverName  = "bsu.csi.outscale.com"
-	TopologyKey = "topology." + DriverName + "/zone"
+	DriverName     = "bsu.csi.outscale.com"
+	TopologyKey    = "topology." + DriverName + "/zone"
+	TopologyK8sKey = "topology.kubernetes.io/zone"
 )
 
 type Driver struct {


### PR DESCRIPTION
This PR aims to support standard topology key `topology.kubernetes.io/zone`.

Closes #447 