### PR TITLE
Fill SnapshotId in Disk structure - v0.X

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -677,6 +677,7 @@ func (c *cloud) GetDiskByName(ctx context.Context, name string, capacityBytes in
 		VolumeID:         volume.GetVolumeId(),
 		CapacityGiB:      int64(volSizeBytes),
 		AvailabilityZone: volume.GetSubregionName(),
+		SnapshotID:       volume.GetSnapshotId(),
 	}, nil
 }
 
@@ -697,6 +698,7 @@ func (c *cloud) GetDiskByID(ctx context.Context, volumeID string) (Disk, error) 
 		VolumeID:         volume.GetVolumeId(),
 		CapacityGiB:      int64(volume.GetSize()),
 		AvailabilityZone: volume.GetSubregionName(),
+		SnapshotID:       volume.GetSnapshotId(),
 	}, nil
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This PR is to fix a bug o idempotency in `CreateVolume` call. Indeed, if another call is submited with the same parameter with snapshotId, the second call with failed with an error.

```
E0117 17:39:32.587993       1 driver.go:112] GRPC error: rpc error: code = AlreadyExists desc = Volume already exists, but was restored from a different snapshot than snap-XXXX
```

**What is this PR about? / Why do we need it?**
All calls **must** be idempotent therefore this is necessary in order not to be stuck

**What testing is done?**
Test of the cloud Call have been added to detect any future regression on this.
