### PR TITLE
add a sleep before the backoff and polling mechanisms for volume crea…

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -383,6 +383,8 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 		}
 		return true, nil
 	}
+	// Implement a delay before retrying
+	time.Sleep(4* time.Second) // Adjust this based on expected volume creation time
 
 	backoff := util.EnvBackoff()
 	waitErr := wait.ExponentialBackoff(backoff, createVolumeCallBack)


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
On a random Outscale account (shared among several developers) it tooks 4s on average.

Adding a sleep command before initiating the backoff and polling logic is to ensure that the volume creation have enough time to start properly before checking their status. 
This ensures that the backoff logic is applied only when necessary and after the initial setup time has been accounted for and  help avoid issues where the polling might start before the operation has had a chance to initiate, which could lead to unnecessary retries. 
