### PR TITLE
Fix extra arg

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -61,34 +61,40 @@ Kubernetes: `>=1.20`
 | resources | object | `{}` | Specify limits of resources used by the pod |
 | serviceAccount.controller.annotations | object | `{}` | Annotations to add to the Controller ServiceAccount |
 | serviceAccount.snapshot.annotations | object | `{}` | Annotations to add to the Snapshot ServiceAccount |
+| sidecars.attacherImage.additionalArgs | list | `[]` |  |
+| sidecars.attacherImage.additionalClusterRoleRules | string | `nil` |  |
 | sidecars.attacherImage.enableHttpEndpoint | bool | `false` | Enable http endpoint to get metrics of the container |
 | sidecars.attacherImage.enableLivenessProbe | bool | `false` | Enable liveness probe for the container |
 | sidecars.attacherImage.httpEndpointPort | string | `"8090"` | Port of the http endpoint |
 | sidecars.attacherImage.leaderElection | object | `{}` | Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration) |
 | sidecars.attacherImage.repository | string | `"registry.k8s.io/sig-storage/csi-attacher"` |  |
-| sidecars.attacherImage.tag | string | `"v3.3.0"` |  |
+| sidecars.attacherImage.tag | string | `"v4.7.0"` |  |
 | sidecars.livenessProbeImage.port | string | `"9808"` | Port of the liveness of the main container |
 | sidecars.livenessProbeImage.repository | string | `"registry.k8s.io/sig-storage/livenessprobe"` |  |
-| sidecars.livenessProbeImage.tag | string | `"v2.5.0"` |  |
+| sidecars.livenessProbeImage.tag | string | `"v2.14.0"` |  |
 | sidecars.nodeDriverRegistrarImage.enableHttpEndpoint | bool | `false` | Enable http endpoint to get metrics of the container |
 | sidecars.nodeDriverRegistrarImage.enableLivenessProbe | bool | `false` | Enable liveness probe for the container |
 | sidecars.nodeDriverRegistrarImage.httpEndpointPort | string | `"8093"` | Port of the http endpoint |
 | sidecars.nodeDriverRegistrarImage.repository | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` |  |
-| sidecars.nodeDriverRegistrarImage.tag | string | `"v2.3.0"` |  |
+| sidecars.nodeDriverRegistrarImage.tag | string | `"v2.12.0"` |  |
+| sidecars.provisionerImage.additionalArgs | list | `[]` |  |
+| sidecars.provisionerImage.additionalClusterRoleRules | string | `nil` |  |
 | sidecars.provisionerImage.enableHttpEndpoint | bool | `false` | Enable http endpoint to get metrics of the container |
 | sidecars.provisionerImage.enableLivenessProbe | bool | `false` | Enable liveness probe for the container |
-| sidecars.provisionerImage.extraArgs.--feature-gates | string | `"NodeSwap=true"` |  |
-| sidecars.provisionerImage.extraArgs.--feature-gates | string | `"CrossNamespaceVolumeDataSource=true"` |  |
 | sidecars.provisionerImage.httpEndpointPort | string | `"8089"` | Port of the http endpoint |
 | sidecars.provisionerImage.leaderElection | object | `{}` | Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration) |
 | sidecars.provisionerImage.repository | string | `"registry.k8s.io/sig-storage/csi-provisioner"` |  |
-| sidecars.provisionerImage.tag | string | `"v3.0.0"` |  |
+| sidecars.provisionerImage.tag | string | `"v4.0.0"` |  |
+| sidecars.resizerImage.additionalArgs | list | `[]` |  |
+| sidecars.resizerImage.additionalClusterRoleRules | string | `nil` |  |
 | sidecars.resizerImage.enableHttpEndpoint | bool | `false` | Enable http endpoint to get metrics of the container |
 | sidecars.resizerImage.enableLivenessProbe | bool | `false` | Enable liveness probe for the container |
 | sidecars.resizerImage.httpEndpointPort | string | `"8092"` | Port of the http endpoint |
 | sidecars.resizerImage.leaderElection | object | `{}` | Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration) |
 | sidecars.resizerImage.repository | string | `"registry.k8s.io/sig-storage/csi-resizer"` |  |
-| sidecars.resizerImage.tag | string | `"v1.3.0"` |  |
+| sidecars.resizerImage.tag | string | `"v1.12.0"` |  |
+| sidecars.snapshotterImage.additionalArgs | list | `[]` |  |
+| sidecars.snapshotterImage.additionalClusterRoleRules | string | `nil` |  |
 | sidecars.snapshotterImage.enableHttpEndpoint | bool | `false` | Enable http endpoint to get metrics of the container |
 | sidecars.snapshotterImage.enableLivenessProbe | bool | `false` | Enable liveness probe for the container |
 | sidecars.snapshotterImage.httpEndpointPort | string | `"8091"` | Port of the http endpoint |

--- a/osc-bsu-csi-driver/templates/clusterrole-attacher.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-attacher.yaml
@@ -21,4 +21,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments/status" ]
     verbs: [ "patch" ]
-
+  {{- with .Values.sidecars.attacherImage.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}

--- a/osc-bsu-csi-driver/templates/clusterrole-provisioner.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-provisioner.yaml
@@ -36,3 +36,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
+  {{- with .Values.sidecars.provisionerImage.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}

--- a/osc-bsu-csi-driver/templates/clusterrole-resizer.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-resizer.yaml
@@ -30,4 +30,8 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  {{- with .Values.sidecars.resizerImage.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}
 {{- end}}
+

--- a/osc-bsu-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -22,4 +22,7 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+    {{- with .Values.sidecars.snapshotterImage.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -145,10 +145,9 @@ spec:
             {{- if .Values.extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}
-            {{- if .Values.sidecars.provisionerImage.extraArgs }}
-            {{- range $key, $value := .Values.sidecars.provisionerImage.extraArgs }}
-            - {{ $key }}={{ $value }}
-            {{- end }}
+            # Dynamically adding additionalArgs from values.yaml
+            {{- range .Values.sidecars.provisionerImage.additionalArgs }}
+            - {{ . }}
             {{- end }}
             - --leader-election=true
             {{- if .Values.sidecars.provisionerImage.leaderElection.leaseDuration }}
@@ -192,6 +191,10 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
+            # Dynamically adding additionalArgs from values.yaml
+            {{- range .Values.sidecars.attacherImage.additionalArgs }}
+            - {{ . }}
+            {{- end }}
             - --leader-election=true
             {{- if .Values.sidecars.attacherImage.leaderElection.leaseDuration }}
             - --leader-election-lease-duration={{ .Values.sidecars.attacherImage.leaderElection.leaseDuration }}
@@ -233,6 +236,10 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
+            # Dynamically adding additionalArgs from values.yaml
+            {{- range .Values.sidecars.snapshotterImage.additionalArgs }}
+            - {{ . }}
+            {{- end }}
             - --leader-election=true
             {{- if .Values.sidecars.snapshotterImage.leaderElection.leaseDuration }}
             - --leader-election-lease-duration={{ .Values.sidecars.snapshotterImage.leaderElection.leaseDuration }}
@@ -277,6 +284,10 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             - --timeout={{ .Values.timeout }}
+            # Dynamically adding additionalArgs from values.yaml
+            {{- range .Values.sidecars.resizerImage.additionalArgs }}
+            - {{ . }}
+            {{- end }}
             - --leader-election=true
             {{- if .Values.sidecars.resizerImage.leaderElection.leaseDuration }}
             - --leader-election-lease-duration={{ .Values.sidecars.resizerImage.leaderElection.leaseDuration }}

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -34,7 +34,7 @@ backoff:
 sidecars:
   provisionerImage:
     repository: registry.k8s.io/sig-storage/csi-provisioner
-    tag: "v5.1.0"
+    tag: "v4.0.0"
     # -- Enable http endpoint to get metrics of the container
     enableHttpEndpoint: false
     # -- Port of the http endpoint
@@ -43,10 +43,9 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
-    extraArgs:
-      --feature-gates: "CrossNamespaceVolumeDataSource=true"
-      --feature-gates: "NodeSwap=true"
-      # ... other arguments that can be used by the provisioner when it is needed. 
+    additionalArgs: []
+    # Grant additional permissions to external-provisioner
+    additionalClusterRoleRules:
   attacherImage:
     repository: registry.k8s.io/sig-storage/csi-attacher
     tag: "v4.7.0"
@@ -58,6 +57,9 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    additionalArgs: []
+    # Grant additional permissions to external-provisioner
+    additionalClusterRoleRules:
   snapshotterImage:
     repository: registry.k8s.io/sig-storage/csi-snapshotter
     tag: "v4.2.1"
@@ -69,6 +71,9 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    additionalArgs: []
+    # Grant additional permissions to external-provisioner
+    additionalClusterRoleRules:
   livenessProbeImage:
     repository: registry.k8s.io/sig-storage/livenessprobe
     tag: "v2.14.0"
@@ -85,6 +90,9 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    additionalArgs: []
+    # Grant additional permissions to external-provisioner
+    additionalClusterRoleRules:
   nodeDriverRegistrarImage:
     repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
     tag: "v2.12.0"

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -34,7 +34,7 @@ backoff:
 sidecars:
   provisionerImage:
     repository: registry.k8s.io/sig-storage/csi-provisioner
-    tag: "v3.0.0"
+    tag: "v5.1.0"
     # -- Enable http endpoint to get metrics of the container
     enableHttpEndpoint: false
     # -- Port of the http endpoint
@@ -49,7 +49,7 @@ sidecars:
       # ... other arguments that can be used by the provisioner when it is needed. 
   attacherImage:
     repository: registry.k8s.io/sig-storage/csi-attacher
-    tag: "v3.3.0"
+    tag: "v4.7.0"
     # -- Enable http endpoint to get metrics of the container
     enableHttpEndpoint: false
     # -- Port of the http endpoint
@@ -71,12 +71,12 @@ sidecars:
     leaderElection: {}
   livenessProbeImage:
     repository: registry.k8s.io/sig-storage/livenessprobe
-    tag: "v2.5.0"
+    tag: "v2.14.0"
     # -- Port of the liveness of the main container
     port: "9808"
   resizerImage:
     repository: registry.k8s.io/sig-storage/csi-resizer
-    tag: "v1.3.0"
+    tag: "v1.12.0"
     # -- Enable http endpoint to get metrics of the container
     enableHttpEndpoint: false
     # -- Port of the http endpoint
@@ -87,7 +87,7 @@ sidecars:
     leaderElection: {}
   nodeDriverRegistrarImage:
     repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.3.0"
+    tag: "v2.12.0"
     # -- Enable http endpoint to get metrics of the container
     enableHttpEndpoint: false
     # -- Port of the http endpoint


### PR DESCRIPTION
This PR introduces the ability to pass custom additional arguments to the sidecar containers for the provisioner, attacher, resizer, and snapshotter controllers. This change aims to enhance the flexibility and configurability of the controllers (https://github.com/outscale/osc-bsu-csi-driver/issues/809) 
According to this PR and to enable CrossNamespaceVolumeDataSource and this documentation. https://kubernetes-csi.github.io/docs/cross-namespace-data-sources.html 
We have to enable CrossNamespaceVolumeDataSource [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) for the kube-apiserver and kube-controller-manager ( example in [osc rke k8s cluster
](https://github.com/outscale/osc-k8s-rke-cluster)

We have to : 
1. Locate the cluster configuration file, typically named cluster.yaml.
2. Modify the file to add the CrossNamespaceVolumeDataSource=true feature gate for both the API server and Controller Manager under the extra_args section.


services:
  kube-api:
    extra_args:
      feature-gates: "CrossNamespaceVolumeDataSource=true"
      
  kube-controller:
    extra_args:
      feature-gates: "CrossNamespaceVolumeDataSource=true"

You need to apply changes to your cluster,
rke up --config cluster.yaml

This will ensure that the API server and Controller Manager start with the CrossNamespaceVolumeDataSource feature gate enabled.

Next, we need to install or upgrade the OSC BSU CSI driver to ensure it is aware of the CrossNamespaceVolumeDataSource feature.
Example using helm 
helm upgrade --install  --wait          --wait-for-jobs                 osc-bsu-csi-driver ./osc-bsu-csi-driver               --namespace kube-system                 --set enableVolumeScheduling=true               --set enableVolumeResizing=true                 --set enableVolumeSnapshot=true   --set sidecars.provisionerImage.additionalArgs[0]=--feature-gates=CrossNamespaceVolumeDataSource=true 

Now that the feature is enabled, we need to allow cross-namespace access using a ReferenceGrant. This object grants permission to access resources (like volume snapshots) in a different namespace.
