### PR TITLE
Increase default provisioner, resizer, snapshotter retry-interval-max

### DIFF
--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -137,6 +137,9 @@ spec:
         - name: csi-provisioner
           image: {{ printf "%s:%s" .Values.sidecars.provisionerImage.repository .Values.sidecars.provisionerImage.tag }}
           args:
+            {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.provisionerImage.additionalArgs)) }}
+            - --retry-interval-max=30m
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             {{- if .Values.enableVolumeScheduling }}
@@ -189,6 +192,9 @@ spec:
         - name: csi-attacher
           image: {{ printf "%s:%s" .Values.sidecars.attacherImage.repository .Values.sidecars.attacherImage.tag }}
           args:
+            {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.attacherImage.additionalArgs)) }}
+            - --retry-interval-max=30m
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             # Dynamically adding additionalArgs from values.yaml
@@ -235,6 +241,9 @@ spec:
         - name: csi-snapshotter
           image: {{ printf "%s:%s" .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
           args:
+            {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.snapshotterImage.additionalArgs)) }}
+            - --retry-interval-max=30m
+            {{- end }}
             - --csi-address=$(ADDRESS)
             # Dynamically adding additionalArgs from values.yaml
             {{- range .Values.sidecars.snapshotterImage.additionalArgs }}
@@ -281,6 +290,9 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
           imagePullPolicy: Always
           args:
+            {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.resizerImage.additionalArgs)) }}
+            - --retry-interval-max=30m
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             - --timeout={{ .Values.timeout }}


### PR DESCRIPTION
Is this a bug fix or adding new feature?
Improvement

What is this PR about? / Why do we need it?
Today, the max backoff period for any sidecar RPC is 5 minutes. This is problematic if the user has a misconfigured K8s object (such as invalid IOPS for volume type) because the invalid request will be retried every 5 minutes until user resolves the issue.