### PR TITLE
Update sidecar timeout values

### DIFF
--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -137,6 +137,9 @@ spec:
         - name: csi-provisioner
           image: {{ printf "%s:%s" .Values.sidecars.provisionerImage.repository .Values.sidecars.provisionerImage.tag }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.provisioner.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             {{- if .Values.enableVolumeScheduling }}
@@ -190,6 +193,9 @@ spec:
         - name: csi-attacher
           image: {{ printf "%s:%s" .Values.sidecars.attacherImage.repository .Values.sidecars.attacherImage.tag }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.provisioner.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             - --leader-election=true
@@ -232,6 +238,9 @@ spec:
         - name: csi-snapshotter
           image: {{ printf "%s:%s" .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.provisioner.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --leader-election=true
             {{- if .Values.sidecars.snapshotterImage.leaderElection.leaseDuration }}
@@ -274,6 +283,9 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
           imagePullPolicy: Always
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.provisioner.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             - --timeout={{ .Values.timeout }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
The timeout value for the external snapshotter affects the CreateSnapshot and DeleteSnapshot operations, which are responsible for interacting with the storage backend to create or delete volume snapshots.

https://github.com/kubernetes-csi/external-snapshotter/blob/5ad0cfb6f47daf5812a2ba921c9b19e7f92a2422/README.md?plain=1#L234

When the default timeout is too short, snapshot operations that could have eventually succeeded are instead retried, consuming additional resources and increasing load on the CSI driver, Kubernetes control plane, and storage backend.
By extending the timeout, the system can avoid unnecessary retries, which improves efficiency and reduces operational delays, ultimately leading to smoother workload performance.

Also This default timeout of 15 seconds for sidecar operations, such as ControllerPublishVolume (attaching) and ControllerUnpublishVolume (detaching), can lead to errors, especially in cases where operations take longer due to factors like network latency, high resource usage, or large cloud environments.

**What is this PR about? / Why do we need it?**

**What testing is done?** 
