### PR TITLE
support Volume Group Snapshots k8s 1.27

### DIFF
--- a/osc-bsu-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -17,11 +17,23 @@ rules:
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch", "create"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+   - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["update", "patch"]
     {{- with .Values.sidecars.snapshotterImage.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
** new feature?**
Add the support og VolumegroupSnapshot introduced in k8s 1.27 
https://kubernetes.io/blog/2023/05/08/kubernetes-1-27-volume-group-snapshot-alpha/

