### PR TITLE
Add default kube-api-qps, burst, and worker-threads values in CSI driver

### DIFF
--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -150,6 +150,11 @@ spec:
             {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
+            {{- if not (regexMatch "(-kube-api-qps)|(-kube-api-burst)|(-worker-threads)" (join " " .Values.sidecars.provisionerImage.additionalArgs)) }}
+            - --kube-api-qps=20
+            - --kube-api-burst=100
+            - --worker-threads=100
+            {{- end }}
             {{- if .Values.enableVolumeScheduling }}
             - --feature-gates=Topology=true
             {{- end}}
@@ -209,6 +214,11 @@ spec:
             {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
+            {{- if not (regexMatch "(-kube-api-qps)|(-kube-api-burst)|(-worker-threads)" (join " " .Values.sidecars.attacherImage.additionalArgs)) }}
+            - --kube-api-qps=20
+            - --kube-api-burst=100
+            - --worker-threads=100
+            {{- end }}
             # Dynamically adding additionalArgs from values.yaml
             {{- range .Values.sidecars.attacherImage.additionalArgs }}
             - {{ . }}
@@ -316,6 +326,11 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.verbosity }}
             - --timeout={{ .Values.timeout }}
+            {{- if not (regexMatch "(-kube-api-qps)|(-kube-api-burst)|(-workers)" (join " " .Values.sidecars.resizerImage.additionalArgs)) }}
+            - --kube-api-qps=20
+            - --kube-api-burst=100
+            - --workers=100
+            {{- end }}
             # Dynamically adding additionalArgs from values.yaml
             {{- range .Values.sidecars.resizerImage.additionalArgs }}
             - {{ . }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
For context : https://docs.google.com/document/d/1wyq_9-EFsr7U90JMYXOHxoJlChwWXJqWsah3ctmuDDo/edit?tab=t.0


Added values: 
--kube-api-qps
* helps throttle the rate at which the CSI driver interacts with the Kubernetes API. If the provisioner is making too many API requests, this can overwhelm the API server, leading to performance degradation.
* Default Value: Kubernetes components usually have a default QPS value (e.g., 5 or 10). However, for high-performance workloads, a higher value is often set.
=> Setting --kube-api-qps=20 means that the CSI driver can send up to 20 requests per second to the API server.

--kube-api-burst:
* Definition: This flag controls how many API requests can be sent in a short burst. It defines the burst rate of requests above the QPS rate.
* Usage: This is useful when there is a sudden need for a higher rate of API requests, such as during volume provisioning spikes. Once the burst rate is exceeded, the QPS rate will throttle the requests.
* Default Value: The default burst rate is usually higher than the QPS rate. For example, a default burst rate could be 10 when the QPS rate is 5. It allows the system to handle short spikes without overwhelming the Kubernetes API.
=> setting --kube-api-burst=100, you're allowing the CSI provisioner to send up to 100 requests in a burst when necessary, which helps manage high-demand periods.

 --worker-threads:
* Definition: This flag sets the number of concurrent worker threads that the CSI provisioner uses to handle volume provisioning tasks.
* Usage: More worker threads mean that the CSI provisioner can handle multiple requests in parallel, such as creating volumes or managing snapshots. This can improve overall throughput and responsiveness, particularly in clusters with high storage activity.
* Default Value: Provisioners often default to a smaller number of worker threads (e.g., 10). In high-performance environments, increasing the number of threads helps balance the workload better.
=> Setting --worker-threads=100 allows the CSI provisioner to handle up to 100 concurrent volume provisioning tasks, which can improve efficiency in larger clusters.

=> These settings help optimize the interaction between the CSI driver and the Kubernetes API server,
The ideal values for these flags depend on your cluster size, node count, and storage usage patterns. In small clusters, lower values might be sufficient, while larger clusters may need higher values.

