### PR TITLE
Set RuntimeDefault as default seccompProfile in securityContext

### DIFF
--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -47,6 +47,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.containerSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: osc-plugin
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -134,6 +138,10 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-provisioner
           image: {{ printf "%s:%s" .Values.sidecars.provisionerImage.repository .Values.sidecars.provisionerImage.tag }}
           args:
@@ -189,6 +197,10 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.provisionerImage.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-attacher
           image: {{ printf "%s:%s" .Values.sidecars.attacherImage.repository .Values.sidecars.attacherImage.tag }}
           args:
@@ -237,6 +249,10 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.attacherImage.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.enableVolumeSnapshot }}
         - name: csi-snapshotter
           image: {{ printf "%s:%s" .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
@@ -283,6 +299,10 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sidecars.snapshotterImage.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if .Values.enableVolumeResizing }}
@@ -335,6 +355,10 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.resizerImage.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
@@ -346,6 +370,10 @@ spec:
               mountPath: /csi
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sidecars.livenessProbeImage.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
         - name: socket-dir

--- a/osc-bsu-csi-driver/templates/node.yaml
+++ b/osc-bsu-csi-driver/templates/node.yaml
@@ -44,10 +44,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.node.securityContext }}
+      securityContext:  
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: osc-plugin
-          securityContext:
-            privileged: true
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -91,6 +93,11 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.node.containerSecurityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
         - name: node-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
           args:
@@ -126,6 +133,10 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.nodeDriverRegistrarImage.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:
@@ -136,6 +147,10 @@ spec:
               mountPath: /csi
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sidecars.livenessProbeImage.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
         - name: kubelet-dir

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -43,6 +43,11 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
     additionalArgs: []
     # Grant additional permissions to external-provisioner
     additionalClusterRoleRules:
@@ -57,6 +62,11 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
     additionalArgs: []
     # Grant additional permissions to external-provisioner
     additionalClusterRoleRules:
@@ -71,6 +81,11 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
     additionalArgs: []
     # Grant additional permissions to external-provisioner
     additionalClusterRoleRules:
@@ -79,6 +94,11 @@ sidecars:
     tag: "v2.13.1"
     # -- Port of the liveness of the main container
     port: "9808"
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   resizerImage:
     repository: registry.k8s.io/sig-storage/csi-resizer
     tag: "v1.11.2"
@@ -90,6 +110,11 @@ sidecars:
     enableLivenessProbe: false
     # -- Customize leaderElection, you can specify `leaseDuration`, `renewDeadline` and/or `retryPeriod`. Each value must be in an acceptable time.ParseDuration format.(Ref: https://pkg.go.dev/flag#Duration)
     leaderElection: {}
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
     additionalArgs: []
     # Grant additional permissions to external-provisioner
     additionalClusterRoleRules:
@@ -102,6 +127,12 @@ sidecars:
     httpEndpointPort: "8093"
     # -- Enable liveness probe for the container
     enableLivenessProbe: false
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+  
 
 # -- Specify image pull secrets
 imagePullSecrets: []
@@ -142,7 +173,6 @@ resources:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
 nodeSelector: {}
 
 #@ignored
@@ -187,11 +217,20 @@ node:
   tolerateAllTaints: true
   # -- Pod tolerations
   tolerations: []
-
+  # Privileged containers always run as `Unconfined`, which means that they are not restricted by a seccomp profile.
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    privileged: true
 serviceAccount:
   controller:
     # -- Annotations to add to the Controller ServiceAccount
     annotations: {}
+    # securityContext on the controller container (see sidecars for securityContext on sidecar containers)
+    containerSecurityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   snapshot:
     # -- Annotations to add to the Snapshot ServiceAccount
     annotations: {}


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
feat: enable securityContext.seccompProfile
refer to https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads

What is Seccomp ?
Seccomp stands for secure computing mode and has been a feature of the Linux kernel since version 2.6.12. It can be used to sandbox the privileges of a process, restricting the calls it is able to make from userspace into the kernel. Kubernetes lets you automatically apply seccomp profiles loaded onto a node to your Pods and containers.

As a beta feature, you can configure Kubernetes to use the profile that the container runtime prefers by default
https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads

Important
Note: It is not possible to apply a seccomp profile to a container running with privileged: true set in the container's securityContext. Privileged containers always run as Unconfined.
