### PR TITLE
fix PV will be encrypted failing due to restictive securityContext

### DIFF
--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -219,8 +219,12 @@ node:
   tolerations: []
   # Privileged containers always run as `Unconfined`, which means that they are not restricted by a seccomp profile.
   containerSecurityContext:
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false  # Allow write operations needed for volume management
     privileged: true
+    allowPrivilegeEscalation: true  # Ensure privileges can be escalated for volume management if needed
+    seccompProfile:
+      type: Unconfined     # temporarily disable seccomp restrictions to allow necessary system calls for LUKS volumes
+serviceAccount:
 serviceAccount:
   controller:
     # -- Annotations to add to the Controller ServiceAccount


### PR DESCRIPTION
### Problem Summary:
After adding the `securityContext` to both the controller and node, the pod was no longer able to mount or access the LUKS-encrypted volumes. This issue was traced to restrictive security settings that prevented necessary operations such as mounting, decrypting, and interacting with the LUKS-encrypted block devices.

### Cause:
The restrictive security context blocked certain operations required by the CSI driver or the pod itself to manage the encrypted volumes. In particular, settings like `allowPrivilegeEscalation: false` and `seccompProfile: RuntimeDefault` were blocking essential system calls or preventing the pod from escalating privileges when needed.

### Changes Made:
To resolve the issue, the following changes were applied:
   - Set `privileged: true` to allow full access to host resources for managing encrypted volumes.
   - Enabled `allowPrivilegeEscalation: true` to ensure the pod can escalate privileges when necessary.
   - Disabled seccomp restrictions temporarily by setting `seccompProfile: Unconfined` to allow system calls needed by LUKS or the CSI driver.
   - Set `readOnlyRootFilesystem: false` to allow necessary write operations.

These changes allow the pod and node to successfully mount and interact with the LUKS-encrypted volumes by ensuring that no critical operations are blocked by the security context.



