### PR TITLE
Fix luks expand

### DIFF
--- a/examples/kubernetes/encryption/specs/storageclass.yaml
+++ b/examples/kubernetes/encryption/specs/storageclass.yaml
@@ -6,10 +6,11 @@ metadata:
 provisioner: bsu.csi.outscale.com
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  encrypted: "true"
+  encrypted: 'true'
   luks-cipher: aes-xts-plain64
   type: io1
-  iopsPerGB: "50"
+  iopsPerGB: '50'
   csi.storage.k8s.io/node-stage-secret-name: luks-key
   csi.storage.k8s.io/node-stage-secret-namespace: encryption
-
+  csi.storage.k8s.io/node-expand-secret-name: luks-key
+  csi.storage.k8s.io/node-expand-secret-namespace: encryption

--- a/pkg/driver/luks/luks.go
+++ b/pkg/driver/luks/luks.go
@@ -12,6 +12,6 @@ type LuksService interface {
 	CheckLuksPassphrase(devicePath string, passphrase string) bool
 	LuksOpen(devicePath string, encryptedDeviceName string, passphrase string) (bool, error)
 	IsLuksMapping(devicePath string) (bool, string, error)
-	LuksResize(deviceName string) error
+	LuksResize(deviceName string, passphrase string) error
 	LuksClose(deviceName string) error
 }

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -111,8 +111,8 @@ func (m *NodeMounter) IsLuksMapping(devicePath string) (bool, string, error) {
 	return IsLuksMapping(m, devicePath)
 }
 
-func (m *NodeMounter) LuksResize(deviceName string) error {
-	return LuksResize(m, deviceName)
+func (m *NodeMounter) LuksResize(deviceName string, passphrase string) error {
+	return LuksResize(m, deviceName, passphrase)
 }
 
 func (m *NodeMounter) LuksClose(deviceName string) error {


### PR DESCRIPTION
Hello,

it seems that to make luks expand working, we need to pass passphrase to `cryptsetup resize` command.

I have some dirty modifications to show you how it should work.
I did not modify the tests and mock stuff, I'm sorry, I'm not a developper.

But it's a working modifications.
Indeed of go code updates, we need also to update StorageClass to pass passphrase to NodeExpandVolume.
```yaml
  csi.storage.k8s.io/node-expand-secret-name: luks-key
  csi.storage.k8s.io/node-expand-secret-namespace: encryption
```

This pull request should not be merged, it's just to show one way to do it :)

