### PR TITLE
remove duplicate sc and misplaced containerSecurityContext

### DIFF
--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -225,18 +225,9 @@ node:
     seccompProfile:
       type: Unconfined     # temporarily disable seccomp restrictions to allow necessary system calls for LUKS volumes
 serviceAccount:
-serviceAccount:
   controller:
-    # -- Annotations to add to the Controller ServiceAccount
     annotations: {}
-    # securityContext on the controller container (see sidecars for securityContext on sidecar containers)
-    containerSecurityContext:
-      seccompProfile:
-        type: RuntimeDefault
-      readOnlyRootFilesystem: true
-      allowPrivilegeEscalation: false
   snapshot:
-    # -- Annotations to add to the Snapshot ServiceAccount
     annotations: {}
 
 credentials:


### PR DESCRIPTION
**Is this a bug fix **

**What is this PR about? / Why do we need it?**
Key Changes and Clarifications:

- I removed the duplicate serviceAccount block, keeping only one instance with controller and snapshot annotations.
- I removed misplacement of containerSecurityContext:
              The containerSecurityContext is applied correctly under the node section and the sidecars (like provisioner, 
              attacher, etc.). The serviceAccount block should not contain any security context, as it is only responsible for 
              ServiceAccount metadata.



