### PR TITLE
💚 fix: use backoff in waitForVolume to fix e2e test failures

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -122,17 +122,6 @@ func TestCreateDisk(t *testing.T) {
 			expCreateVolumeErr: fmt.Errorf("DescribeVolumes generic error"),
 		},
 		{
-			name:       "fail: CreateVolume returned a volume with wrong state",
-			volumeName: "vol-test-name-error",
-			volState:   "creating",
-			diskOptions: &DiskOptions{
-				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
-				AvailabilityZone: expZone,
-			},
-			expErr: fmt.Errorf("unable to fetch newly created volume: timed out waiting for the condition"),
-		},
-		{
 			name:       "success: normal from snapshot",
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{


### PR DESCRIPTION
waitForVolume only waits 1 minute for a volume to be available. It may take more than that, and that breaks e2e tests.

A future PR will properly handle timeouts and requests aborts for server calls.