### PR TITLE
✨ feat: support custom backoff policies

### DIFF
--- a/pkg/cloud/backoff.go
+++ b/pkg/cloud/backoff.go
@@ -1,0 +1,48 @@
+package cloud
+
+import (
+	"context"
+	"net/http"
+	"slices"
+
+	"k8s.io/klog/v2"
+)
+
+// RetryOnHTTPCodes defines the list of HTTP codes for which we backoff.
+var RetryOnHTTPCodes = []int{429, 500, 502, 503, 504}
+
+type BackoffPolicy func(ctx context.Context, resp *http.Response, err error) (bool, error)
+
+// NoRetryOnErrors is the default backoff policy: retry only on RetryOnHTTPCodes http statuses.
+// No retry on errors.
+func NoRetryOnErrors(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	switch {
+	case resp != nil && slices.Contains(RetryOnHTTPCodes, resp.StatusCode):
+		klog.FromContext(ctx).V(5).Info("Retrying...")
+		return false, nil
+	case err != nil:
+		return false, err
+	default:
+		return true, nil
+	}
+}
+
+// NoRetryOnErrors is an alternate policy that retries on all errors.
+func RetryOnErrors(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	switch {
+	case resp != nil && slices.Contains(RetryOnHTTPCodes, resp.StatusCode):
+		klog.FromContext(ctx).V(5).Info("Retrying...")
+		return false, nil
+	case err != nil:
+		klog.FromContext(ctx).V(5).Error(err, "Retrying...")
+		return false, nil
+	default:
+		return true, nil
+	}
+}
+
+var _ BackoffPolicy = NoRetryOnErrors
+var _ BackoffPolicy = RetryOnErrors
+
+// DefaultBackoffPolicy is the default BackoffPolicy (NoRetryOnErrors)
+var DefaultBackoffPolicy = NoRetryOnErrors

--- a/pkg/cloud/logging.go
+++ b/pkg/cloud/logging.go
@@ -36,7 +36,7 @@ func logAPICall(ctx context.Context, call string, request, resp any, httpResp *h
 	}
 	switch {
 	case err != nil && httpResp == nil:
-		logger.V(3).Error(err, "OAPI error", call, "OAPI", call)
+		logger.V(3).Error(err, "OAPI error", "OAPI", call)
 	case httpResp == nil:
 	case httpResp.StatusCode > 299 && logger.V(3).Enabled():
 		logger.Info("OAPI error response: "+truncatedBody(httpResp), "OAPI", call, "http_status", httpResp.Status)

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -47,8 +47,8 @@ func TestNewControllerService(t *testing.T) {
 		testErr    = errors.New("test error")
 		testRegion = "test-region"
 
-		getNewCloudFunc = func(expectedRegion string) func(region string) (cloud.Cloud, error) {
-			return func(region string) (cloud.Cloud, error) {
+		getNewCloudFunc = func(expectedRegion string) func(region string, opts ...cloud.CloudOption) (cloud.Cloud, error) {
+			return func(region string, opts ...cloud.CloudOption) (cloud.Cloud, error) {
 				if region != expectedRegion {
 					t.Fatalf("expected region %q but got %q", expectedRegion, region)
 				}
@@ -60,7 +60,7 @@ func TestNewControllerService(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		region                string
-		newCloudFunc          func(string) (cloud.Cloud, error)
+		newCloudFunc          func(string, ...cloud.CloudOption) (cloud.Cloud, error)
 		newMetadataFuncErrors bool
 		expectPanic           bool
 	}{
@@ -72,7 +72,7 @@ func TestNewControllerService(t *testing.T) {
 		{
 			name:   "AWS_REGION variable set, newCloud errors",
 			region: "foo",
-			newCloudFunc: func(region string) (cloud.Cloud, error) {
+			newCloudFunc: func(region string, opts ...cloud.CloudOption) (cloud.Cloud, error) {
 				return nil, testErr
 			},
 			expectPanic: true,

--- a/tests/e2e/pre_provisioning.go
+++ b/tests/e2e/pre_provisioning.go
@@ -23,14 +23,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	osccloud "github.com/outscale/osc-bsu-csi-driver/pkg/cloud"
+	bsucsidriver "github.com/outscale/osc-bsu-csi-driver/pkg/driver"
 	"github.com/outscale/osc-bsu-csi-driver/tests/e2e/driver"
 	"github.com/outscale/osc-bsu-csi-driver/tests/e2e/testsuites"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-
-	bsucsidriver "github.com/outscale/osc-bsu-csi-driver/pkg/driver"
 )
 
 const (
@@ -72,7 +71,7 @@ var _ = Describe("[bsu-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Skip(fmt.Sprintf("env %q not set", awsAvailabilityZonesEnv))
 		}
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
-		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
+		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))] //nolint: gosec
 		region := availabilityZone[0 : len(availabilityZone)-1]
 
 		diskOptions := &osccloud.DiskOptions{
@@ -82,7 +81,7 @@ var _ = Describe("[bsu-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Tags:             map[string]string{osccloud.VolumeNameTagKey: dummyVolumeName},
 		}
 		var err error
-		cloud, err = osccloud.NewCloudWithoutMetadata(region)
+		cloud, err = osccloud.NewCloud(region, osccloud.WithoutMetadata())
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}


### PR DESCRIPTION
Tests and production may have different requirements re. OAPI calls backoff. This allows setting a custom backoff policy. The default policy also backoffs on additional 5XX errors.