### PR TITLE
⬆️ deploy: switch to distroless image, strip binary

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -43,9 +43,9 @@ jobs:
         osc_access_key: ${{ secrets.OSC_ACCESS_KEY }}
         osc_secret_key: ${{ secrets.OSC_SECRET_KEY }}
         osc_region: ${{ secrets.OSC_REGION }}
-        image_id: ${{ secrets.OMI_ID }}
-        rke_version: "v1.6.5"
-        kubernetes_version: "v1.30.7-rancher1-1"
+        image_id: ${{ vars.OMI_ID }}
+        rke_version: ${{ vars.RKE_VERSION_E2E }}
+        kubernetes_version: ${{ vars.K8S_VERSION_E2E }}
     - name: Wait to access the cluster
       uses: nick-invision/retry@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 ARG GOLANG_IMAGE_TAG=1.23.4-bookworm
-ARG RUNTIME_IMAGE_TAG=3.13
+# Tools are taken from Debian 12
+ARG TOOLS_IMAGE_TAG=12
+# Distroless debug is used to get a busybox shell
+ARG RUNTIME_IMAGE_TAG=debug-dca9008b864a381b5ce97196a4d8399ac3c2fa65
 
 # Build image
 FROM golang:${GOLANG_IMAGE_TAG} AS builder
@@ -19,16 +22,67 @@ ENV CGO_ENABLED=0
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN make build
 
+# Source image for all fs binaries (mkfs, mount/umount, fsck, ...)
+FROM debian:${TOOLS_IMAGE_TAG} AS debian
+
+RUN apt-get update && apt-get install -y --no-install-recommends util-linux e2fsprogs mount xfsprogs cryptsetup-bin
+
+# Scratch image with all binaries & libs
+FROM scratch AS tmp
+
+COPY --from=builder /build/bin/osc-bsu-csi-driver /bin/osc-bsu-csi-driver
+COPY --from=debian /bin/sh \
+        /bin/mount \
+        /bin/umount /bin/
+COPY --from=debian /sbin/blkid \
+        /sbin/blockdev \
+        /sbin/cryptsetup \
+        /sbin/dumpe2fs \
+        /sbin/e2freefrag \
+        /sbin/e2fsck \
+        /sbin/e2image \
+        /sbin/e2mmpstatus \
+        /sbin/e2undo \
+        /sbin/fsck \
+        /sbin/fsck.ext2 \
+        /sbin/fsck.ext3 \
+        /sbin/fsck.ext4 \
+        /sbin/fsck.xfs \
+        /sbin/mke2fs \
+        /sbin/mkfs \
+        /sbin/mkfs.ext2 \
+        /sbin/mkfs.ext3 \
+        /sbin/mkfs.ext4 \
+        /sbin/mkfs.xfs \
+        /sbin/resize2fs \
+        /sbin/xfs_repair /sbin/
+COPY --from=debian /lib/x86_64-linux-gnu/libargon2.so.1 \
+        /lib/x86_64-linux-gnu/libblkid.so.1 \
+        /lib/x86_64-linux-gnu/libc.so.6 \
+        /lib/x86_64-linux-gnu/libcom_err.so.2 \
+        /lib/x86_64-linux-gnu/libcrypto.so.3 \
+        /lib/x86_64-linux-gnu/libcryptsetup.so.12 \
+        /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 \
+        /lib/x86_64-linux-gnu/libe2p.so.2 \
+        /lib/x86_64-linux-gnu/libext2fs.so.2 \
+        /lib/x86_64-linux-gnu/libinih.so.1 \
+        /lib/x86_64-linux-gnu/libjson-c.so.5 \
+        /lib/x86_64-linux-gnu/libm.so.6 \
+        /lib/x86_64-linux-gnu/libmount.so.1 \
+        /lib/x86_64-linux-gnu/libpcre2-8.so.0 \
+        /lib/x86_64-linux-gnu/libpopt.so.0 \
+        /lib/x86_64-linux-gnu/libselinux.so.1 \
+        /lib/x86_64-linux-gnu/libtinfo.so.6 \
+        /lib/x86_64-linux-gnu/libudev.so.1 \
+        /lib/x86_64-linux-gnu/liburcu.so.8 \
+        /lib/x86_64-linux-gnu/libuuid.so.1 \
+        /lib/x86_64-linux-gnu/libz.so.1 \
+        /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+COPY --from=debian /lib64/ld-linux-x86-64.so.2 /lib64/
+COPY --from=debian /etc/mke2fs.conf /etc/
+
 # Final IMAGE
-FROM alpine:${RUNTIME_IMAGE_TAG}
-RUN apk add --no-cache \
-            ca-certificates=20220614-r0 \
-            e2fsprogs=1.45.7-r0 \
-            xfsprogs=5.10.0-r0 \
-            xfsprogs-extra=5.10.0-r0 \
-            blkid=2.37.4-r0 \
-            e2fsprogs-extra=1.45.7-r0 \
-            cryptsetup=2.3.7-r0
-COPY  --from=builder /build/bin/osc-bsu-csi-driver /bin/osc-bsu-csi-driver
+FROM gcr.io/distroless/static-debian12:${RUNTIME_IMAGE_TAG}
+COPY --from=tmp / /
 
 ENTRYPOINT ["/bin/osc-bsu-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 # Docker env
 DOCKERFILES := $(shell find . -type f -name '*Dockerfile*' !  -path "./debug/*" )
-LINTER_VERSION := v1.17.5
+LINTER_VERSION := v2.12.0
 
 E2E_ENV ?= "e2e/osc-bsu-csi-driver:0.0"
 E2E_ENV_RUN ?= "e2e-osc-bsu-csi-driver"
@@ -25,7 +25,7 @@ IMAGE_TAG ?= $(shell git describe --tags --always --dirty)
 VERSION ?= ${IMAGE_TAG}
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS ?= "-X ${PKG}/pkg/util.driverVersion=${VERSION} -X ${PKG}/pkg/util.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/util.buildDate=${BUILD_DATE}"
+LDFLAGS ?= "-s -w -X ${PKG}/pkg/util.driverVersion=${VERSION} -X ${PKG}/pkg/util.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/util.buildDate=${BUILD_DATE}"
 GO111MODULE := on
 GOPROXY := direct
 TRIVY_IMAGE := aquasec/trivy:0.30.0
@@ -72,7 +72,7 @@ test:
 .PHONY: dockerlint
 dockerlint:
 	@echo "Lint images =>  $(DOCKERFILES)"
-	$(foreach image,$(DOCKERFILES), echo "Lint  ${image} " ; docker run --rm -i hadolint/hadolint:${LINTER_VERSION} hadolint - < ${image} || exit 1 ; )
+	$(foreach image,$(DOCKERFILES), echo "Lint  ${image} " ; docker run --rm -i hadolint/hadolint:${LINTER_VERSION} hadolint --info DL3008 -t warning - < ${image} || exit 1 ; )
 
 .PHONY: test-e2e-single-az-run
 test-e2e-single-az-run:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,33 +2,13 @@
 [![Project Graduated](https://docs.outscale.com/fr/userguide/_images/Project-Graduated-green.svg)](https://docs.outscale.com/en/userguide/Open-Source-Projects.html)
 # Outscale Block Storage Unit (BSU) CSI driver
 
-> **_NOTE:_** We are currently maintaining two versions of the plugin: v1.X (`master` branch) and v0.X (`OSC-MIGRATION` branch). If you are using the v0.X, we provide a guide to migrate to the new version [here](#migration-from-v0x-to-v100). The version v0.X will still receive bug and CVE fixes for as long it is used but no more features should be added.
+> **_NOTE:_** We are currently maintaining two versions of the plugin: v1.X (`master` branch) and v0.X (`OSC-MIGRATION` branch). If you are using the v0.X, we provide a guide to migrate to the new version [here](#migration-from-v0x-to-v100). The version v0.X will still receive bug and CVE fixes for as long it is used but no new features will be added.
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/osc-bsu-csi-driver)](https://artifacthub.io/packages/search?repo=osc-bsu-csi-driver)
+
 ## Overview
 
 The Outscale Block Storage Unit Container Storage Interface (CSI) Driver provides a [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) interface used by Container Orchestrators to manage the lifecycle of 3DS outscale BSU volumes.
-
-## Kernel Minimum Requirements for XFS Support
-
-To use the XFS file system with this CSI driver, ensure your system meets the following requirements:
-
-Minimum Linux Kernel Version
-* **Recommended Minimum Kernel Version** 3.13
-Required Packages
-* **xfsprogs** (Version: 5.10.0-r0): Provides utilities for managing XFS file systems. Kernel support for XFS is required.
-* **e2fsprogs** (Version: 1.45.7-r0): Utilities for managing ext2, ext3, and ext4 file systems. While not directly related to XFS, it is useful for various disk operations.
-* **cryptsetup** (Version: 2.3.7-r0): Required for disk encryption, which can be used in conjunction with XFS.
-
-You can verify your kernel version and XFS module support with the following commands:
-# Check the current kernel version
-`uname -r`
-
-# Check if the XFS module is loaded
-`lsmod | grep xfs`
-
-# Load the XFS module if it is not loaded
-`sudo modprobe xfs`
 
 ## CSI Specification Compability Matrix
 
@@ -40,6 +20,7 @@ You can verify your kernel version and XFS module support with the following com
 | v0.1.0 -  v1.4.0 | [v1.8.0](https://github.com/container-storage-interface/spec/releases/tag/v1.8.0) | 1.20            | 1.30                    |
 
 ## Features
+
 The following CSI gRPC calls are implemented:
 * **Controller Service**: CreateVolume, DeleteVolume, ControllerPublishVolume, ControllerUnpublishVolume, ControllerGetCapabilities, ControllerExpandVolume, ValidateVolumeCapabilities, CreateSnapshot, DeleteSnapshot, ListSnapshots
 * **Node Service**: NodeStageVolume, NodeUnstageVolume, NodePublishVolume, NodeUnpublishVolume, NodeExpandVolume, NodeGetCapabilities, NodeGetInfo, NodeGetVolumeStats
@@ -51,45 +32,54 @@ The following CSI gRPC calls are **not yet** implemented:
 * **Identity Service**: N/A
 
 ### CreateVolume Parameters
-There are several optional parameters that could be passed into `CreateVolumeRequest.parameters` map:
+There are several optional parameters that can be passed into `CreateVolumeRequest.parameters` map:
 
-| Parameters                                       | Values                | Default | Description                                                                                                                                                                                                 |
-| ------------------------------------------------ | --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "csi.storage.k8s.io/fstype"                      | xfs, ext2, ext3, ext4 | ext4    | File system type that will be formatted during volume creation                                                                                                                                              |
-| "type"                                           | io1, gp2, standard    | gp2     | BSU volume type                                                                                                                                                                                             |
-| "iopsPerGB"                                      |                       |         | I/O operations per second per GiB. Required when io1 volume type is specified                                                                                                                               |
-| "encrypted"                                      | "true", "false"       | "false" | Specify if we want to encrypt te disk or not                                                                                                                                                                |
-| "csi.storage.k8s.io/node-stage-secret-name"      | string                |         | The name of the secret  (See [template](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#node-stage-secret))                                                                |
-| "csi.storage.k8s.io/node-stage-secret-namespace" | string                |         | The namespace of the secret (See [template](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#node-stage-secret))                                                            |
-| "kmsKeyId"                                       | string                |         | Not yet supported                                                                                                                                                                                           |
-| "luks-cipher"                                    | string                |         | LUKS encryption cipher to use  (See [doc](https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/on-disk-format-luks2.pdf) or `cryptsetup --help`). Default value depends on the cryptsetup version.     |
-| "luks-hash"                                      | string                |         | Derivation Password hash algorithm (See [doc](https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/on-disk-format-luks2.pdf) or `cryptsetup --help`). Default value depends on the cryptsetup version. |
-| "luks-key-size"                                  | string                |         | Size of the encryption key  (See [doc](https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/on-disk-format-luks2.pdf) or `cryptsetup --help`). Default value depends on the cryptsetup version.        |
+| Parameter                                      | Values                | Default | Description |
+| ---------------------------------------------- | --------------------- | ------- | ----------- |
+| csi.storage.k8s.io/fstype                      | xfs, ext2, ext3, ext4 | ext4    | File system type that will used to format the volume |
+| type                                           | io1, gp2, standard    | gp2     | BSU volume type |
+| iopsPerGB                                      |                       |         | I/O operations per second per GiB. Required when io1 volume type is specified |
+| encrypted                                      | true, false           | false   | Specify if we want to encrypt the disk or not |
+| csi.storage.k8s.io/node-stage-secret-name      | string                |         | The name of the secret  (See [template](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#node-stage-secret)) |
+| csi.storage.k8s.io/node-stage-secret-namespace | string                |         | The namespace of the secret (See [template](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#node-stage-secret)) |
+| kmsKeyId                                       | string                |         | Not yet supported |
+| luks-cipher                                    | string                |         | LUKS encryption cipher to use  (See [doc](https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/on-disk-format-luks2.pdf) or `cryptsetup --help`). Default value depends on the cryptsetup version |
+| luks-hash                                      | string                |         | Derivation Password hash algorithm (See [doc](https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/on-disk-format-luks2.pdf) or `cryptsetup --help`). Default value depends on the cryptsetup version |
+| luks-key-size                                  | string                |         | Size of the encryption key  (See [doc](https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/on-disk-format-luks2.pdf) or `cryptsetup --help`). Default value depends on the cryptsetup version |
 
 **Notes**:
-* The parameters are case sensitive.
+* Parameter names are case sensitive.
 
 ## Use with Kubernetes
+
 Following sections are Kubernetes specific. If you are Kubernetes user, use followings for driver features, installation steps and examples.
 
 ### Features
 * **Static Provisioning** - create a new or migrating existing BSU volumes, then create persistence volume (PV) from the BSU volume and consume the PV from container using persistence volume claim (PVC).
 * **Dynamic Provisioning** - uses persistence volume claim (PVC) to request the Kuberenetes to create the BSU volume on behalf of user and consumes the volume from inside container.
 * **Mount Option** - mount options could be specified in persistence volume (PV) to define how the volume should be mounted.
-* **Block Volume** (beta since 1.14) - consumes the BSU volume as a raw block device for latency sensitive application eg. MySql
+* **Block Volume** (beta since 1.14) - consumes the BSU volume as a raw block device for latency sensitive application eg. MySql.
 * **Volume Snapshot** - creating volume snapshots and restore volume from snapshot.
-* **Volume Encryption** - Not supported yet.
+* **Volume Encryption** - using Luks & cryptsetup.
+
 ### Prerequisites
 - Cluster K8S with compatible version (See [Version](README.md#csi-specification-compability-matrix))
 - The plugin needs AK/SK to interact with Outscale BSU API, so you can create an AK/SK using an eim user, for example, with a proper permission by attaching [a policy like](./example-eim-policy.json) 
+
 ### Chart Configuration
 See [Helm Chart Configuration](helm.md)
+
 ### Installation
 See [Deploy](deploy.md)
 
+### Troubleshooting
+See [Troubleshooting](troubleshooting.md)
+
 ### Migration from v0.X to v1.0.0
 See [Migration Process](migration.md)
+
 ## Examples
+
 Make sure you follow the [Prerequisites](README.md#Prerequisites) before the examples:
 * [Dynamic Provisioning](../examples/kubernetes/dynamic-provisioning)
 * [Block Volume](../examples/kubernetes/block-volume)
@@ -99,4 +89,5 @@ Make sure you follow the [Prerequisites](README.md#Prerequisites) before the exa
 * [Encryption](../examples/kubernetes/encryption/)
 
 ## Development
+
 See [Development Process](development.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,24 @@
+# Troubleshooting
+
+## Shell access to the CSI pod
+
+A busybox shell is available for troubleshooting. You can connect to a CSI pod using:
+
+```
+kubectl exec -it [pod name] -c osc-plugin -n kube-system -- /busybox/sh
+```
+
+Filesystem management tools are available on CSI node pods.
+
+## XFS
+
+To use XFS volumes, XFS must be enabled on the worker nodes host kernel.
+XFS support is included in most recent Linux distributions.
+
+You can check XFS module support with the following commands:
+
+### Check if the XFS module is loaded
+`lsmod | grep xfs`
+
+### Load the XFS module if it is not loaded
+`sudo modprobe xfs`


### PR DESCRIPTION
Image is based on a static distroless base image. The debug variant is used, it includes busybox to enable shell access to the pods. This saves ~40MB.

The Go binary is stripped, saving ~20MB.

Image size is reduced from 121MB to 63MB.

