### PR TITLE
✨ feat: automatically compute maxBsuVolumes

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -48,7 +48,7 @@ Kubernetes: `>=1.20`
 | image.repository | string | `"outscale/osc-bsu-csi-driver"` | Container image to use |
 | image.tag | string | `"v1.6.0"` | Container image tag to deploy |
 | imagePullSecrets | list | `[]` | Specify image pull secrets |
-| maxBsuVolumes | string | `"39"` | Maximum volume to attach to a node (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html)) |
+| maxBsuVolumes | string | `""` | Maximum number of volumes that can be attached to a node, autocomputed by default (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html)) |
 | nameOverride | string | `""` | Override name of the app (instead of `osc-bsu-csi-driver`) |
 | noProxy | string | `""` | Value used to create environment variable NO_PROXY |
 | node.args | list | `[]` | Node controller command line additional args |

--- a/osc-bsu-csi-driver/helm_test.go
+++ b/osc-bsu-csi-driver/helm_test.go
@@ -254,7 +254,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		dep := getDaemonSet(t)
 		require.Len(t, dep.Spec.Template.Spec.Containers, 3)
 		manager := dep.Spec.Template.Spec.Containers[0]
-		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.5.2", manager.Image)
+		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.6.0", manager.Image)
 		assert.Equal(t, []string{
 			"node",
 			"--endpoint=$(CSI_ENDPOINT)",
@@ -273,7 +273,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		}, manager.Resources)
 	})
 
-		t.Run("MAX_BSU_VOLUMES can be set", func(t *testing.T) {
+	t.Run("MAX_BSU_VOLUMES can be set", func(t *testing.T) {
 		dep := getDaemonSet(t, "maxBsuVolumes=39")
 		require.Len(t, dep.Spec.Template.Spec.Containers, 3)
 		manager := dep.Spec.Template.Spec.Containers[0]

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -223,8 +223,8 @@ extraCreateMetadata: false
 # -- Region to use, otherwise it will be looked up via metadata. By providing this parameter, the controller will not require to access the metadata.
 region: ""
 
-# -- Maximum volume to attach to a node (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html))
-maxBsuVolumes: "39"
+# -- Maximum number of volumes that can be attached to a node, autocomputed by default (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html))
+maxBsuVolumes: ""
 
 # -- Default filesystem for the volume if no `FsType` is set in `StorageClass`
 defaultFsType: "ext4"

--- a/pkg/driver/mocks/mock_metadata_service.go
+++ b/pkg/driver/mocks/mock_metadata_service.go
@@ -81,6 +81,20 @@ func (mr *MockMetadataServiceMockRecorder) GetInstanceType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceType", reflect.TypeOf((*MockMetadataService)(nil).GetInstanceType))
 }
 
+// GetMountedDevices mocks base method.
+func (m *MockMetadataService) GetMountedDevices() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMountedDevices")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetMountedDevices indicates an expected call of GetMountedDevices.
+func (mr *MockMetadataServiceMockRecorder) GetMountedDevices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMountedDevices", reflect.TypeOf((*MockMetadataService)(nil).GetMountedDevices))
+}
+
 // GetRegion mocks base method.
 func (m *MockMetadataService) GetRegion() string {
 	m.ctrl.T.Helper()

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -51,8 +51,9 @@ func TestSanity(t *testing.T) {
 				Region:           "region",
 				AvailabilityZone: "az",
 			},
-			mounter:  newFakeMounter(),
-			inFlight: internal.NewInFlight(),
+			maxVolumes: 39,
+			mounter:    newFakeMounter(),
+			inFlight:   internal.NewInFlight(),
 		},
 	}
 	defer func() {


### PR DESCRIPTION
There is a limit of 40 volumes per VM (including the root volume, which means 39 additional volumes).

This limit includes:
* volumes mounted by the OS at boot,
* volumes mounted by the CSI.

Previously, the code always returned 39 available volumes, without accounting for volumes mounted by the OS.

This PR computes the actual number of volumes.

Ideally, we would call OAPI to retrieve the list of attached volumes, but this would require the node controller to have access to OAPI.

The computation is performed at startup, any volume mounted afterward is not taken into account.