### PR TITLE
✨ feat: allow online/offline change of size/volumeType/iopspergb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: github.com/container-storage-interface/spec
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    groups:
+      k8s:
+        applies-to: version-updates
+        patterns:
+          - "k8s.io/*"
+        update-types:
+          - "patch"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
     - name: ⬇️ Checkout repository
       uses: actions/checkout@v4
-    - name: ⬇️ Checkout CAPOSC
-      uses: actions/checkout@v4
-      with:
-        repository: 'outscale/cluster-api-provider-outscale'
-        path: "cluster-api-provider-outscale"
     - name: 🔐 Set ak/sk name based on runner region
       run: .github/scripts/runneraksk.sh
     - name: ⬇️ Install kubectl
@@ -59,6 +54,7 @@ jobs:
         CLUSTER_NAME: "csi"
         IMAGE_NAME: ${{ vars.IMG_MANAGEMENT }}
         CCM: true
+        KUSTOMIZE_PATH: "tests/e2e/capi-kustomize"
     - name: 📦 Build & Push the Docker image
       run: |
         docker login ${{ vars.REGISTRY }} -u admin -p ${{ secrets.HARBOR_ADMIN_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,8 @@ helm_deploy:
 			--wait-for-jobs  \
 			osc-bsu-csi-driver ./osc-bsu-csi-driver \
 			--namespace kube-system \
-			--set enableVolumeScheduling=true \
-			--set enableVolumeResizing=true \
 			--set enableVolumeSnapshot=true \
+			--set enableVolumeAttributesClass=true \
 			--set region=${OSC_REGION} \
 			--set image.repository=$(TARGET_IMAGE) \
 			--set image.tag=$(TARGET_TAG) \

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,21 +18,22 @@ The Outscale Block Storage Unit Container Storage Interface (CSI) Driver provide
 | v0.0.15         | [v1.5.0](https://github.com/container-storage-interface/spec/releases/tag/v1.5.0)   | 1.20            | 1.23                    |
 | v0.1.0 - v1.3.0 | [v1.5.0](https://github.com/container-storage-interface/spec/releases/tag/v1.5.0)   | 1.20            | 1.23                    |
 | v0.1.0 - v1.6.X | [v1.8.0](https://github.com/container-storage-interface/spec/releases/tag/v1.8.0)   | 1.20            | 1.30                    |
-| v1.7.X -        | [v1.10.0](https://github.com/container-storage-interface/spec/releases/tag/v1.10.0) | 1.20            | 1.30                    |
+| v1.7.X -        | [v1.10.0](https://github.com/container-storage-interface/spec/releases/tag/v1.10.0) | 1.20            | 1.31                    |
 
 ## Features
 
 The following CSI gRPC calls are implemented:
-* **Controller Service**: CreateVolume, DeleteVolume, ControllerPublishVolume, ControllerUnpublishVolume, ControllerGetCapabilities, ControllerExpandVolume, ValidateVolumeCapabilities, CreateSnapshot, DeleteSnapshot, ListSnapshots
+* **Controller Service**: CreateVolume, DeleteVolume, ControllerPublishVolume, ControllerUnpublishVolume, ControllerGetCapabilities, ControllerExpandVolume, ControllerModifyVolume, ValidateVolumeCapabilities, CreateSnapshot, DeleteSnapshot, ListSnapshots
 * **Node Service**: NodeStageVolume, NodeUnstageVolume, NodePublishVolume, NodeUnpublishVolume, NodeExpandVolume, NodeGetCapabilities, NodeGetInfo, NodeGetVolumeStats
 * **Identity Service**: GetPluginInfo, GetPluginCapabilities, Probe
 
-The following CSI gRPC calls are **not yet** implemented:
+The following CSI gRPC calls are currently not implemented:
 * **Controller Service**: GetCapacity, ListVolumes, ControllerGetVolume
 * **Node Service**: N/A
 * **Identity Service**: N/A
 
-### CreateVolume Parameters
+### CreateVolume
+
 There are several optional parameters that can be passed into `CreateVolumeRequest.parameters` map:
 
 | Parameter                                      | Values                | Default | Description |
@@ -51,16 +52,23 @@ There are several optional parameters that can be passed into `CreateVolumeReque
 **Notes**:
 * Parameter names are case sensitive.
 
+### ControllerExpandVolume
+
+Both cold volumes (volumes not mounted on a VM) and hot volumes (volumes mounted) can be resized.
+
+### ControllerModifyVolume
+
+Volume type (volumeType) and IOPS (iopspergb) may be changed using VolumeAttributeClasses. Both cold volumes (volumes not mounted on a VM) and hot volumes (volumes mounted) can be updated.
+
 ## Use with Kubernetes
 
 Following sections are Kubernetes specific. If you are Kubernetes user, use followings for driver features, installation steps and examples.
 
 ### Features
-* **Static Provisioning** - create a new or migrating existing BSU volumes, then create persistence volume (PV) from the BSU volume and consume the PV from container using persistence volume claim (PVC).
-* **Dynamic Provisioning** - uses persistence volume claim (PVC) to request the Kuberenetes to create the BSU volume on behalf of user and consumes the volume from inside container.
-* **Mount Option** - mount options could be specified in persistence volume (PV) to define how the volume should be mounted.
-* **Block Volume** (beta since 1.14) - consumes the BSU volume as a raw block device for latency sensitive application eg. MySql.
-* **Volume Snapshot** - creating volume snapshots and restore volume from snapshot.
+* **Static Provisioning** - create a new or migrate existing BSU volumes, and mounts them in pods through persistent volume claims (PVC),
+* **Dynamic Provisioning** - use persistent volume claims (PVC) to create on-demand volumes and mount them in pods,
+* **Block Volumes** - mount raw block devices for latency sensitive application eg. MySql,
+* **Volume Snapshots** - create volume snapshots and restore volumes from snapshots,
 * **Volume Encryption** - using Luks & cryptsetup.
 
 ### Prerequisites
@@ -81,12 +89,12 @@ See [Migration Process](migration.md)
 
 ## Examples
 
-Make sure you follow the [Prerequisites](README.md#Prerequisites) before the examples:
 * [Dynamic Provisioning](../examples/kubernetes/dynamic-provisioning)
 * [Block Volume](../examples/kubernetes/block-volume)
 * [Volume Snapshot](../examples/kubernetes/snapshot)
-* [Configure StorageClass](../examples/kubernetes/storageclass)
+* [StorageClasses](../examples/kubernetes/storageclass)
 * [Volume Resizing](../examples/kubernetes/resizing)
+* [Volume Updates (VolumeAttributeClasses)](../examples/kubernetes/volume-attribute-class)
 * [Encryption](../examples/kubernetes/encryption/)
 
 ## Development

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -29,8 +29,6 @@ kubectl apply -f osc-secret.yaml --namespace=kube-system
 ```shell
 helm install --upgrade osc-bsu-csi-driver oci://docker.io/outscalehelm/osc-bsu-csi-driver \
     --namespace kube-system \
-    --set enableVolumeScheduling=true \
-    --set enableVolumeResizing=true \
     --set enableVolumeSnapshot=true \
     --set region=$OSC_REGION
 ```

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -38,8 +38,8 @@ Kubernetes: `>=1.20`
 | customEndpoint | string | `""` | Use customEndpoint (url with protocol) ex: https://api.eu-west-2.outscale.com/api/v1 |
 | defaultFsType | string | `"ext4"` | Default filesystem for the volume if no `FsType` is set in `StorageClass` |
 | enableSnapshotCrossNamespace | bool | `false` | Enable snapshot cross namespace True if enable snapshot cross namespace |
-| enableVolumeResizing | bool | `false` | Enable volume resizing True if enable volume resizing |
-| enableVolumeScheduling | bool | `true` | Enable schedule volume for dynamic volume provisioning True if enable volume scheduling for dynamic volume provisioning |
+| enableVolumeResizing | bool | `true` | Enable volume resizing (deprecated, cannot be disabled) |
+| enableVolumeScheduling | bool | `true` | Enable schedule volume for dynamic volume provisioning (deprecated, cannot be disabled) |
 | enableVolumeSnapshot | bool | `false` | Enable volume snapshot True if enable volume snapshot |
 | extraCreateMetadata | bool | `false` | Add pv/pvc metadata to plugin create requests as parameters |
 | extraSnapshotTags | object | `{}` | Add extra tags on snapshots |

--- a/examples/kubernetes/resizing/README.md
+++ b/examples/kubernetes/resizing/README.md
@@ -1,9 +1,6 @@
 ## Volume Resizing
 This example shows how to resize BSU persistence volume using volume resizing features.
 
-**Note**
-- BSU has a limitation with volume modification only when state is available. Refer to [API documentation](https://docs.outscale.com/api#updatevolume) for more details.
-
 ## Usage
 1. Add `allowVolumeExpansion: true` in the StorageClass spec in [example manifest](./spec/sc.yaml) to enable volume expansion. You can only expand a PVC if its storage class’s allowVolumeExpansion field is set to true
 

--- a/examples/kubernetes/snapshot-cross-namespace/README.md
+++ b/examples/kubernetes/snapshot-cross-namespace/README.md
@@ -47,8 +47,6 @@ You must manually enable it by setting the following flag on both the **kube-api
 ```bash
 helm install --upgrade osc-bsu-csi-driver oci://docker.io/outscalehelm/osc-bsu-csi-driver \
   --namespace kube-system \
-  --set enableVolumeScheduling=true \
-  --set enableVolumeResizing=true \
   --set enableVolumeSnapshot=true \
   --set enableSnapshotCrossNamespace=true \   # Enable cross-namespace snapshot support
   --set region=$OSC_REGION

--- a/examples/kubernetes/volume-attribute-class/README.md
+++ b/examples/kubernetes/volume-attribute-class/README.md
@@ -1,0 +1,17 @@
+# Configuring VolumeAttributeClass
+
+This example shows how to modify a volume using VolumeAttributeClass.
+It requires Kubernetes 1.31 or above.
+
+## Usage
+
+Deploy the example:
+```sh
+kubectl apply -f specs/
+```
+
+Update the pvc:
+```yaml
+spec:
+  volumeAttributesClass: bsu-vac-after
+```

--- a/examples/kubernetes/volume-attribute-class/specs/ns.yaml
+++ b/examples/kubernetes/volume-attribute-class/specs/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "volume-attribute-class-p"

--- a/examples/kubernetes/volume-attribute-class/specs/pvc.yaml
+++ b/examples/kubernetes/volume-attribute-class/specs/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bsu-claim
+  namespace: volume-attribute-class-p
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: bsu-sc
+  volumeAttributesClass: bsu-vac
+  resources:
+    requests:
+      storage: 4Gi

--- a/examples/kubernetes/volume-attribute-class/specs/storageclass.yaml
+++ b/examples/kubernetes/volume-attribute-class/specs/storageclass.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: bsu-sc
+  namespace: volume-attribute-class-p
+provisioner: bsu.csi.outscale.com
+volumeBindingMode: WaitForFirstConsumer

--- a/examples/kubernetes/volume-attribute-class/specs/volumeattributeclass.yaml
+++ b/examples/kubernetes/volume-attribute-class/specs/volumeattributeclass.yaml
@@ -1,0 +1,17 @@
+kind: VolumeAttributesClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: bsu-vac
+provisioner: bsu.csi.outscale.com
+parameters:
+  iopspergb: "500"
+  volumeType: "io1"
+---
+kind: VolumeAttributesClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: bsu-vac-after
+provisioner: bsu.csi.outscale.com
+parameters:
+  iopspergb: "1000"
+  volumeType: "io1"

--- a/osc-bsu-csi-driver/deploy.sh
+++ b/osc-bsu-csi-driver/deploy.sh
@@ -17,8 +17,8 @@ fi
 helm uninstall osc-bsu-csi-driver  --namespace kube-system
 
 helm install osc-bsu-csi-driver ./osc-bsu-csi-driver \
-     --namespace kube-system --set enableVolumeScheduling=true \
-     --set enableVolumeResizing=true --set enableVolumeSnapshot=true \
+     --namespace kube-system \
+     --set enableVolumeSnapshot=true \
      --set region=$REGION \
-    --set image.repository=$IMAGE_NAME \
-    --set image.tag=$IMAGE_TAG
+     --set image.repository=$IMAGE_NAME \
+     --set image.tag=$IMAGE_TAG

--- a/osc-bsu-csi-driver/helm_test.go
+++ b/osc-bsu-csi-driver/helm_test.go
@@ -62,7 +62,7 @@ func getHelmSpecs(t *testing.T, vars ...string) []runtime.Object {
 
 func TestHelmTemplate(t *testing.T) {
 	t.Run("The chart contains the right objects", func(t *testing.T) {
-		specs := getHelmSpecs(t, "enableVolumeResizing=true", "enableVolumeSnapshot=true")
+		specs := getHelmSpecs(t, "enableVolumeSnapshot=true")
 		require.Len(t, specs, 13)
 		objs := map[string]int{}
 		for _, obj := range specs {
@@ -91,7 +91,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 		return nil
 	}
 	t.Run("The deployment has the right defaults", func(t *testing.T) {
-		dep := getDeployment(t, "enableVolumeResizing=true", "enableVolumeSnapshot=true", "region=eu-west2")
+		dep := getDeployment(t, "enableVolumeSnapshot=true", "region=eu-west2")
 		assert.Equal(t, int32(2), *dep.Spec.Replicas)
 		require.Len(t, dep.Spec.Template.Spec.Containers, 6)
 		manager := dep.Spec.Template.Spec.Containers[0]
@@ -135,7 +135,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 
 	t.Run("Resources can be set globally", func(t *testing.T) {
 		dep := getDeployment(t,
-			"enableVolumeResizing=true", "enableVolumeSnapshot=true",
+			"enableVolumeSnapshot=true",
 			"resources.limits.memory=64Mi", "resources.limits.cpu=10m",
 			"resources.requests.memory=96Mi", "resources.requests.cpu=20m")
 		require.Len(t, dep.Spec.Template.Spec.Containers, 6)
@@ -155,7 +155,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 
 	t.Run("Sidecar resources can be set individually", func(t *testing.T) {
 		dep := getDeployment(t,
-			"enableVolumeResizing=true", "enableVolumeSnapshot=true",
+			"enableVolumeSnapshot=true",
 
 			"sidecars.provisionerImage.resources.limits.memory=65Mi", "sidecars.provisionerImage.resources.limits.cpu=11m",
 			"sidecars.provisionerImage.resources.requests.memory=97Mi", "sidecars.provisionerImage.resources.requests.cpu=21m",
@@ -299,7 +299,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 
 	t.Run("Resources can be set globally", func(t *testing.T) {
 		dep := getDaemonSet(t,
-			"enableVolumeResizing=true", "enableVolumeSnapshot=true",
+			"enableVolumeSnapshot=true",
 			"resources.limits.memory=64Mi", "resources.limits.cpu=10m",
 			"resources.requests.memory=96Mi", "resources.requests.cpu=20m")
 		require.Len(t, dep.Spec.Template.Spec.Containers, 3)
@@ -319,7 +319,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 
 	t.Run("Resources can be overriden globally", func(t *testing.T) {
 		dep := getDaemonSet(t,
-			"enableVolumeResizing=true", "enableVolumeSnapshot=true",
+			"enableVolumeSnapshot=true",
 
 			"resources.limits.memory=64Mi", "resources.limits.cpu=10m",
 			"resources.requests.memory=96Mi", "resources.requests.cpu=20m",

--- a/osc-bsu-csi-driver/templates/clusterrole-provisioner.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-provisioner.yaml
@@ -15,6 +15,11 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "storageclasses" ]
     verbs: [ "get", "list", "watch" ]
+{{- if .Values.enableVolumeAttributesClass }}
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get", "list", "watch" ]
+{{- end}}
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "list", "watch", "create", "update", "patch" ]

--- a/osc-bsu-csi-driver/templates/clusterrole-resizer.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrole-resizer.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enableVolumeResizing }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -24,6 +23,11 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
+{{- if .Values.enableVolumeAttributesClass }}
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get", "list", "watch" ]
+{{- end}}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
@@ -33,4 +37,4 @@ rules:
   {{- with .Values.sidecars.resizerImage.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}
-{{- end}}
+

--- a/osc-bsu-csi-driver/templates/clusterrolebinding-resizer.yaml
+++ b/osc-bsu-csi-driver/templates/clusterrolebinding-resizer.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enableVolumeResizing }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,5 +13,3 @@ roleRef:
   kind: ClusterRole
   name: osc-external-resizer-role
   apiGroup: rbac.authorization.k8s.io
-
-{{- end}}

--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -160,8 +160,8 @@ spec:
             - --kube-api-burst=100
             - --worker-threads=100
             {{- end }}
-            {{- if .Values.enableVolumeScheduling }}
-            - --feature-gates=Topology=true
+            {{- if .Values.enableVolumeAttributesClass }}
+            - --feature-gates=VolumeAttributesClass=true
             {{- end}}
             {{- if .Values.enableSnapshotCrossNamespace }}
             - --feature-gates=CrossNamespaceVolumeDataSource=true
@@ -341,7 +341,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.enableVolumeResizing }}
         - name: csi-resizer
           image: {{ printf "%s:%s" .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -357,6 +356,9 @@ spec:
             - --kube-api-burst=100
             - --workers=100
             {{- end }}
+            {{- if .Values.enableVolumeAttributesClass }}
+            - --feature-gates=VolumeAttributesClass=true
+            {{- end}}
             # Dynamically adding additionalArgs from values.yaml
             {{- range .Values.sidecars.resizerImage.additionalArgs }}
             - {{ . }}
@@ -406,7 +408,6 @@ spec:
           securityContext:  
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- end }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -160,13 +160,11 @@ podAnnotations: {}
 # -- Labels for controller pod
 podLabels: {}
 
-# -- Enable schedule volume for dynamic volume provisioning
-# True if enable volume scheduling for dynamic volume provisioning
+# -- Enable schedule volume for dynamic volume provisioning (deprecated, cannot be disabled)
 enableVolumeScheduling: true
 
-# -- Enable volume resizing
-# True if enable volume resizing
-enableVolumeResizing: false
+# -- Enable volume resizing (deprecated, cannot be disabled)
+enableVolumeResizing: true
 
 # -- Enable volume snapshot
 # True if enable volume snapshot

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -498,6 +498,8 @@ func TestGetDiskByID(t *testing.T) {
 							VolumeId:      &tc.volumeID,
 							SubregionName: &tc.availabilityZone,
 							SnapshotId:    tc.snapshotId,
+							Size:          ptr.To[int32](1),
+							Iops:          ptr.To[int32](100),
 						},
 					},
 				},
@@ -1019,7 +1021,6 @@ func TestResizeDisk(t *testing.T) {
 				},
 			},
 			reqSizeGiB: 2,
-			expErr:     nil,
 		},
 		{
 			name:     "success: with previous expansion",
@@ -1031,7 +1032,6 @@ func TestResizeDisk(t *testing.T) {
 				State:         &state,
 			},
 			reqSizeGiB: 2,
-			expErr:     nil,
 		},
 		{
 			name:                "fail: volume doesn't exist",
@@ -1041,15 +1041,21 @@ func TestResizeDisk(t *testing.T) {
 			expErr:              errors.New("ResizeDisk generic error"),
 		},
 		{
-			name:     "failure: volume in modifying state",
+			name:     "success: volume in modifying state",
 			volumeID: "vol-test",
 			existingVolume: osc.Volume{
 				VolumeId:      &volumeId,
 				Size:          &existingVolumeSize,
 				SubregionName: &defaultZoneVar,
 			},
+			modifiedVolume: osc.UpdateVolumeResponse{
+				Volume: &osc.Volume{
+					VolumeId:      &volumeId,
+					Size:          &modifiedVolumeSize,
+					SubregionName: &defaultZoneVar,
+				},
+			},
 			reqSizeGiB: 2,
-			expErr:     errors.New("ResizeDisk generic error"),
 		},
 	}
 

--- a/pkg/cloud/utils.go
+++ b/pkg/cloud/utils.go
@@ -44,6 +44,8 @@ func (err OAPIError) GRPCCode() codes.Code {
 		return codes.ResourceExhausted // https://github.com/container-storage-interface/spec/blob/master/spec.md#createvolume-errors
 	case code == 4116 || code < 4117: // ErrorNextPageTokenExpired, ErrorInvalidNextPageTokenValue
 		return codes.Aborted // https://github.com/container-storage-interface/spec/blob/master/spec.md#listsnapshots-errors
+	case code == 4202 || code == 4029: // ErrorInvalidIopsSizeRatio, ErrorInvalidIops
+		return codes.InvalidArgument // https://github.com/container-storage-interface/spec/blob/master/spec.md#controllermodifyvolume-errors
 	default:
 		return codes.Internal
 	}

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -49,6 +49,13 @@ func (d *Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCa
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -234,6 +234,20 @@ func (mr *MockCloudMockRecorder) ResizeDisk(ctx, volumeID, reqSize any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeDisk", reflect.TypeOf((*MockCloud)(nil).ResizeDisk), ctx, volumeID, reqSize)
 }
 
+// UpdateDisk mocks base method.
+func (m *MockCloud) UpdateDisk(ctx context.Context, volumeID, volumeType string, iopsPerGB int32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDisk", ctx, volumeID, volumeType, iopsPerGB)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDisk indicates an expected call of UpdateDisk.
+func (mr *MockCloudMockRecorder) UpdateDisk(ctx, volumeID, volumeType, iopsPerGB any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDisk", reflect.TypeOf((*MockCloud)(nil).UpdateDisk), ctx, volumeID, volumeType, iopsPerGB)
+}
+
 // WaitForAttachmentState mocks base method.
 func (m *MockCloud) WaitForAttachmentState(ctx context.Context, volumeID, state string) error {
 	m.ctrl.T.Helper()

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -33,6 +33,7 @@ func TestSanity(t *testing.T) {
 	config.CreateTargetDir = createDir
 	config.CreateStagingDir = createDir
 	config.CheckPath = checkPath
+	config.IdempotentCount = 2
 
 	driverOptions := &DriverOptions{
 		endpoint: endpoint,
@@ -285,6 +286,13 @@ func (c *fakeCloudProvider) ResizeDisk(ctx context.Context, volumeID string, new
 		return int64(util.RoundUpGiB(newSize)) * util.GiB, nil
 	}
 	return 0, cloud.ErrNotFound
+}
+
+func (c *fakeCloudProvider) UpdateDisk(ctx context.Context, volumeID string, volumeType string, iops int32) error {
+	if _, found := c.disks[volumeID]; !found {
+		return cloud.ErrNotFound
+	}
+	return nil
 }
 
 // GetMetadata mocks base method

--- a/pkg/util/mutable_params.go
+++ b/pkg/util/mutable_params.go
@@ -1,0 +1,23 @@
+package util
+
+import "maps"
+
+type MutableParameters interface {
+	GetParameters() map[string]string
+	GetMutableParameters() map[string]string
+}
+
+func GetUpdatedParameters(params MutableParameters) map[string]string {
+	switch {
+	case params.GetMutableParameters() == nil:
+		return params.GetParameters()
+	case params.GetParameters() == nil:
+		return params.GetMutableParameters()
+	default:
+		p := maps.Clone(params.GetParameters())
+		for k, v := range params.GetMutableParameters() {
+			p[k] = v
+		}
+		return p
+	}
+}

--- a/tests/e2e/capi-kustomize/kustomization.yaml
+++ b/tests/e2e/capi-kustomize/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterapi.yaml
+patchesStrategicMerge:
+- volumeattributeclass.yaml

--- a/tests/e2e/capi-kustomize/volumeattributeclass.yaml
+++ b/tests/e2e/capi-kustomize/volumeattributeclass.yaml
@@ -1,0 +1,18 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: csi-control-plane
+  namespace: csi
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          feature-gates: VolumeAttributesClass=true
+          runtime-config: storage.k8s.io/v1beta1=true
+      controllerManager:
+        extraArgs:
+          feature-gates: VolumeAttributesClass=true
+      scheduler:
+        extraArgs:
+          feature-gates: VolumeAttributesClass=true

--- a/tests/e2e/driver/driver.go
+++ b/tests/e2e/driver/driver.go
@@ -18,6 +18,7 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,6 +40,9 @@ type DynamicPVTestDriver interface {
 
 	// GetPassphraseSecret returns the secret
 	GetPassphraseSecret(name string, passphrase string) *v1.Secret
+
+	// GetVolumeAttributesClass returns a StorageClass dynamic provision Persistent Volume
+	GetVolumeAttributesClass(namespace, name, volumeType, iopsPerGB string) *storagev1beta1.VolumeAttributesClass
 }
 
 // PreProvisionedVolumeTestDriver represents an interface for a CSI driver that supports pre-provisioned volume

--- a/tests/e2e/testsuites/dynamically_provisioned_modify_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_modify_volume_tester.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint
+	"github.com/outscale/osc-bsu-csi-driver/pkg/cloud"
+	"github.com/outscale/osc-bsu-csi-driver/tests/e2e/driver"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// DynamicallyProvisionedModifyVolumeTest will provision required StorageClass(es), PVC(s) and Pod(s)
+// Waiting for the PV provisioner to create a new PV
+// Update pvc storage size
+// Waiting for new PVC and PV to be ready
+// And finally attach pvc to the pod and wait for pod to be ready.
+type DynamicallyProvisionedModifyVolumeTest struct {
+	CSIDriver driver.DynamicPVTestDriver
+	Pod       PodDetails
+	Cloud     cloud.Cloud
+	Online    bool
+}
+
+func (t *DynamicallyProvisionedModifyVolumeTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	volume := t.Pod.Volumes[0]
+	baseType := "gp2"
+	baseIops := "100"
+	tvac, _ := volume.SetupVolumeAttributesClass(client, namespace, volume.VolumeAttributeClass, baseType, baseIops, t.CSIDriver)
+	defer tvac.Cleanup()
+	tpvc, _ := volume.SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver)
+	defer tpvc.Cleanup()
+
+	pvcName := tpvc.persistentVolumeClaim.Name
+	pvc, _ := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})
+
+	if t.Online {
+		By("Validate volume can be attached")
+		tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+
+		tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+		By("deploying the pod")
+		tpod.Create()
+		By("checking that the pod is running")
+		tpod.WaitForRunning()
+
+		defer tpod.Cleanup()
+	}
+
+	By("updating the VolumeAttributesClass")
+	updatedName := volume.VolumeAttributeClass + "-new"
+	updatedType := "io1"
+	updatedIops := "200"
+	ntvac, _ := volume.SetupVolumeAttributesClass(client, namespace, updatedName, updatedType, updatedIops, t.CSIDriver)
+	defer ntvac.Cleanup()
+	pvc.Spec.VolumeAttributesClassName = &updatedName
+	_, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+	if err != nil {
+		framework.ExpectNoError(err, fmt.Sprintf("fail to Modify PVC(%s): %v", pvc.Name, err))
+	}
+
+	err = t.WaitForPvToModify(client, namespace, pvc.Spec.VolumeName, updatedType, updatedIops, 10*time.Minute, 10*time.Second)
+	framework.ExpectNoError(err)
+
+	if !t.Online {
+		By("Validate volume can be attached")
+		tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+
+		tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+		By("deploying the pod")
+		tpod.Create()
+		By("checking that the pod is successful")
+		tpod.WaitForSuccess()
+
+		defer tpod.Cleanup()
+	}
+}
+
+// WaitForPvToModify waiting for pvc size to be Modifyd to desired size
+func (t *DynamicallyProvisionedModifyVolumeTest) WaitForPvToModify(client clientset.Interface, ns *v1.Namespace, pvName string, desiredType, desiredIops string, timeout time.Duration, interval time.Duration) error {
+	By(fmt.Sprintf("Waiting up to %v for pv in namespace %q to be complete", timeout, ns.Name))
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
+		newPv, err := client.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		if err != nil {
+			continue
+		}
+		if newPv.Spec.CSI != nil {
+			dsk, err := t.Cloud.GetDiskByID(context.TODO(), newPv.Spec.CSI.VolumeHandle)
+			if err != nil {
+				continue
+			}
+			By(fmt.Sprintf("volumeType %q iops %d", dsk.VolumeType, dsk.IOPSPerGB))
+			if dsk.VolumeType != desiredType || strconv.FormatInt(int64(dsk.IOPSPerGB), 10) != desiredIops {
+				continue
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("gave up after waiting %v for pv %q to update", timeout, pvName)
+}

--- a/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
@@ -16,7 +16,11 @@ package testsuites
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/outscale/osc-bsu-csi-driver/pkg/util"
@@ -25,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 
 	. "github.com/onsi/ginkgo/v2"
 	clientset "k8s.io/client-go/kubernetes"
@@ -38,6 +43,7 @@ import (
 type DynamicallyProvisionedResizeVolumeTest struct {
 	CSIDriver driver.DynamicPVTestDriver
 	Pod       PodDetails
+	Online    bool
 }
 
 func (t *DynamicallyProvisionedResizeVolumeTest) Run(client clientset.Interface, namespace *v1.Namespace) {
@@ -48,11 +54,27 @@ func (t *DynamicallyProvisionedResizeVolumeTest) Run(client clientset.Interface,
 	pvcName := tpvc.persistentVolumeClaim.Name
 	pvc, _ := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	By(fmt.Sprintf("Get pvc name: %v", pvc.Name))
-	originalSize := pvc.Spec.Resources.Requests["storage"]
+
+	var tpod *TestPod
+	if t.Online {
+		By("Validate volume can be attached")
+		tpod = NewTestPod(client, namespace, t.Pod.Cmd)
+
+		tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+		By("deploying the pod")
+		tpod.Create()
+		By("checking that the pod is running")
+		tpod.WaitForRunning()
+
+		defer tpod.Cleanup()
+	}
+
+	newSize := pvc.Spec.Resources.Requests["storage"]
 	delta := resource.Quantity{}
 	delta.Set(util.GiBToBytes(3))
-	originalSize.Add(delta)
-	pvc.Spec.Resources.Requests["storage"] = originalSize
+	newSize.Add(delta)
+	pvc.Spec.Resources.Requests["storage"] = newSize
 
 	By("resizing the pvc")
 	updatedPvc, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
@@ -61,33 +83,60 @@ func (t *DynamicallyProvisionedResizeVolumeTest) Run(client clientset.Interface,
 	}
 	updatedSize := updatedPvc.Spec.Resources.Requests["storage"]
 
-	By("checking the resizing PV result")
-	error := WaitForPvToResize(client, namespace, updatedPvc.Spec.VolumeName, updatedSize, 5*time.Minute, 10*time.Second)
-	framework.ExpectNoError(error)
+	By("waiting for the resize")
+	err = waitForPvToResize(client, namespace, updatedPvc.Spec.VolumeName, updatedSize, 5*time.Minute, 10*time.Second)
+	framework.ExpectNoError(err)
 
-	By("Validate volume can be attached")
-	tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+	if t.Online {
+		err = waitForMountToResize(tpod, updatedSize, 5*time.Minute, 30*time.Second)
+		framework.ExpectNoError(err)
+	}
 
-	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+	if !t.Online {
+		By("Validate volume can be attached")
+		tpod := NewTestPod(client, namespace, t.Pod.Cmd)
 
-	By("deploying the pod")
-	tpod.Create()
-	By("checking that the pods is running")
-	tpod.WaitForSuccess()
+		tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
 
-	defer tpod.Cleanup()
+		By("deploying the pod")
+		tpod.Create()
+		By("checking that the pod is successful")
+		tpod.WaitForSuccess()
+
+		defer tpod.Cleanup()
+	}
 }
 
-// WaitForPvToResize waiting for pvc size to be resized to desired size
-func WaitForPvToResize(c clientset.Interface, ns *v1.Namespace, pvName string, desiredSize resource.Quantity, timeout time.Duration, interval time.Duration) error {
-	By(fmt.Sprintf("Waiting up to %v for pv in namespace %q to be complete", timeout, ns.Name))
+// waitForPvToResize waiting for pvc size to be resized to desired size
+func waitForPvToResize(c clientset.Interface, ns *v1.Namespace, pvName string, desiredSize resource.Quantity, timeout time.Duration, interval time.Duration) error {
+	By(fmt.Sprintf("Waiting up to %v for pv to be resized", timeout))
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
 		newPv, _ := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
 		newPvSize := newPv.Spec.Capacity["storage"]
+		_, _ = fmt.Fprintf(GinkgoWriter, "storage capacity: %v\n", newPvSize.String())
 		if desiredSize.Equal(newPvSize) {
-			By(fmt.Sprintf("Pv size is updated to %v", newPvSize.String()))
+			By("PV size is updated")
 			return nil
 		}
 	}
-	return fmt.Errorf("Gave up after waiting %v for pv %q to complete resizing", timeout, pvName)
+	return fmt.Errorf("gave up waiting for pv %q to resize", pvName)
+}
+
+func waitForMountToResize(tpod *TestPod, desiredSize resource.Quantity, timeout time.Duration, interval time.Duration) error {
+	By(fmt.Sprintf("Waiting up to %v for mount to be resized", timeout))
+	sz, _ := desiredSize.AsInt64()
+	szG := util.BytesToGiB(sz)
+	_, _ = fmt.Fprintf(GinkgoWriter, "expected size %dGB\n", szG)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
+		res, err := e2epodoutput.LookForStringInPodExec(tpod.pod.Namespace, tpod.pod.Name, []string{"df", "-m", "/mnt/test-1"}, "/mnt/test-", execTimeout)
+		framework.ExpectNoError(err)
+		blocks, err := strconv.Atoi(strings.Fields(res)[8])
+		_, _ = fmt.Fprintf(GinkgoWriter, "FS size: %dMB\n", blocks)
+		framework.ExpectNoError(err)
+		if int32(math.Round(float64(blocks)/1024)) == szG {
+			By(fmt.Sprintf("Mount is updated to %dMB", blocks))
+			return nil
+		}
+	}
+	return errors.New("gave up waiting for mount to resize")
 }


### PR DESCRIPTION
Volumes can now be resized while mounted.

Volume type and iops can be changed (mounted or not) using [VolumeAttributeClasses](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) - in beta since v1.31, requiring activation of a feature gate.

Fixes #844, #699