### PR TITLE
🔧 helm: use defaults in updateStrategy

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -60,7 +60,7 @@ Kubernetes: `>=1.20`
 | node.podLabels | object | `{}` | Labels for node controller pod |
 | node.resources | object | `{}` | Node controller DaemonSet resources. If not set, the top-level resources will be used. |
 | node.tolerations | list | `[]` | Pod tolerations |
-| node.updateStrategy | object | `{"rollingUpdate":{"maxSurge":0,"maxUnavailable":"10%"},"type":"RollingUpdate"}` | Node controller DaemonSet update strategy |
+| node.updateStrategy | object | `{"type":"RollingUpdate"}` | Node controller DaemonSet update strategy |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations for controller pod |
 | podLabels | object | `{}` | Labels for controller pod |
@@ -135,7 +135,7 @@ Kubernetes: `>=1.20`
 | sidecars.snapshotterImage.tag | string | `"v8.3.0"` |  |
 | timeout | string | `"60s"` | Timeout for sidecars |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists","tolerationSeconds":300}]` | Pod tolerations |
-| updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Controller deployment update strategy. |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | Controller deployment update strategy. |
 | verbosity | int | `3` | Verbosity level of the plugin |
 
 ----------------------------------------------

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -188,8 +188,6 @@ nodeSelector: {}
 # -- Controller deployment update strategy.
 updateStrategy:
   type: RollingUpdate
-  rollingUpdate:
-    maxUnavailable: 1
 
 #@ignored
 tolerateAllTaints: true
@@ -252,10 +250,6 @@ node:
   # -- Node controller DaemonSet update strategy
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 10%
-
 
 serviceAccount:
   controller:


### PR DESCRIPTION
The Helm chart now only sets the updateStrategy for controller and node. rollingUpdate options are not set anymore, and the Kube defaults are used.

This avoids conflicts if another updateStrategy is set (e.g. Recreate).