### PR TITLE
♻️ refacto: switch code to Go 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/outscale/osc-bsu-csi-driver
 
-go 1.25.3
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/container-storage-interface/spec v1.12.0

--- a/helm/osc-bsu-csi-driver/helm_test.go
+++ b/helm/osc-bsu-csi-driver/helm_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/outscale/goutils/sdk/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -112,7 +111,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 						Name: "osc-csi-bsu",
 					},
 					Key:      "access_key",
-					Optional: ptr.To(true),
+					Optional: new(true),
 				},
 			}},
 			{Name: "OSC_SECRET_KEY", ValueFrom: &corev1.EnvVarSource{
@@ -121,7 +120,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 						Name: "osc-csi-bsu",
 					},
 					Key:      "secret_key",
-					Optional: ptr.To(true),
+					Optional: new(true),
 				},
 			}},
 			{Name: "OSC_REGION", Value: "eu-west2"},
@@ -304,8 +303,8 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 		assert.Equal(t, appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 			RollingUpdate: &appsv1.RollingUpdateDeployment{
-				MaxSurge:       ptr.To(intstr.FromInt(1)),
-				MaxUnavailable: ptr.To(intstr.FromString("20%")),
+				MaxSurge:       new(intstr.FromInt(1)),
+				MaxUnavailable: new(intstr.FromString("20%")),
 			},
 		},
 			dep.Spec.Strategy)
@@ -427,9 +426,9 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 			Limits:   nil,
 		}, manager.Resources)
 		assert.Equal(t, &corev1.SecurityContext{
-			ReadOnlyRootFilesystem:   ptr.To(false),
-			Privileged:               ptr.To(true),
-			AllowPrivilegeEscalation: ptr.To(true),
+			ReadOnlyRootFilesystem:   new(false),
+			Privileged:               new(true),
+			AllowPrivilegeEscalation: new(true),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeUnconfined,
 			},
@@ -536,8 +535,8 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		assert.Equal(t, appsv1.DaemonSetUpdateStrategy{
 			Type: appsv1.OnDeleteDaemonSetStrategyType,
 			RollingUpdate: &appsv1.RollingUpdateDaemonSet{
-				MaxSurge:       ptr.To(intstr.FromInt(2)),
-				MaxUnavailable: ptr.To(intstr.FromString("20%")),
+				MaxSurge:       new(intstr.FromInt(2)),
+				MaxUnavailable: new(intstr.FromString("20%")),
 			},
 		},
 			dep.Spec.UpdateStrategy)

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/outscale/goutils/k8s/batch"
 	"github.com/outscale/goutils/k8s/sdk"
-	"github.com/outscale/goutils/sdk/ptr"
 	"github.com/outscale/osc-bsu-csi-driver/cmd/options"
 	dm "github.com/outscale/osc-bsu-csi-driver/pkg/cloud/devicemanager"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/util"
@@ -658,7 +657,7 @@ func (c *cloud) ListSnapshots(ctx context.Context, volumeID string, maxResults i
 		req.NextPageToken = &nextToken
 		// when specifying NextPageToken, the API requires ResultsPerPage to be set
 		if maxResults == 0 {
-			req.ResultsPerPage = ptr.To(maxResultsLimit)
+			req.ResultsPerPage = new(maxResultsLimit)
 		}
 	}
 	if len(volumeID) != 0 {

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -134,7 +134,7 @@ func TestCreateVolume(t *testing.T) {
 			volOptions: &VolumeOptions{
 				CapacityBytes: util.GiBToBytes(1),
 				SubRegion:     expZone,
-				SnapshotID:    ptr.To("snapshot-test"),
+				SnapshotID:    new("snapshot-test"),
 			},
 			expVolume: &Volume{
 				VolumeID:         "vol-test",
@@ -170,9 +170,9 @@ func TestCreateVolume(t *testing.T) {
 			case tc.expErr != nil && tc.expCreateVolumeErr == nil:
 			case tc.expCreateVolumeErr != nil:
 				mockOscInterface.EXPECT().CreateVolume(gomock.Any(), gomock.Eq(osc.CreateVolumeRequest{
-					ClientToken:   ptr.To(tc.volumeName),
+					ClientToken:   new(tc.volumeName),
 					SubregionName: az,
-					Size:          ptr.To(util.BytesToGiB(tc.volOptions.CapacityBytes)),
+					Size:          new(util.BytesToGiB(tc.volOptions.CapacityBytes)),
 					SnapshotId:    tc.volOptions.SnapshotID,
 					VolumeType:    &typ,
 				})).Return(nil, tc.expCreateVolumeErr)
@@ -186,9 +186,9 @@ func TestCreateVolume(t *testing.T) {
 				nextVol := firstVol
 				nextVol.State = tc.nextState
 				mockOscInterface.EXPECT().CreateVolume(gomock.Any(), gomock.Eq(osc.CreateVolumeRequest{
-					ClientToken:   ptr.To(tc.volumeName),
+					ClientToken:   new(tc.volumeName),
 					SubregionName: az,
-					Size:          ptr.To(util.BytesToGiB(tc.volOptions.CapacityBytes)),
+					Size:          new(util.BytesToGiB(tc.volOptions.CapacityBytes)),
 					SnapshotId:    tc.volOptions.SnapshotID,
 					VolumeType:    &typ,
 				})).Return(&osc.CreateVolumeResponse{
@@ -209,7 +209,7 @@ func TestCreateVolume(t *testing.T) {
 
 					mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Eq(osc.ReadVolumesRequest{
 						Filters:        &osc.FiltersVolume{VolumeIds: &[]string{firstVol.VolumeId}},
-						ResultsPerPage: ptr.To(1),
+						ResultsPerPage: new(1),
 					})).Return(&osc.ReadVolumesResponse{Volumes: &[]osc.Volume{nextVol}}, nil).AnyTimes()
 				}
 				if tc.volOptions.SnapshotID != nil {
@@ -256,7 +256,7 @@ func TestCreateVolume(t *testing.T) {
 		mockOscInterface.EXPECT().CreateVolume(gomock.Any(), gomock.Eq(osc.CreateVolumeRequest{
 			ClientToken:   &volName,
 			SubregionName: "az",
-			Size:          ptr.To(4),
+			Size:          new(4),
 			VolumeType:    ptr.To(osc.VolumeTypeGp2),
 		})).Return(&osc.CreateVolumeResponse{
 			Volume: &firstVolume,
@@ -367,7 +367,7 @@ func TestAttachVolume(t *testing.T) {
 			if tc.expErr == nil {
 				mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Eq(osc.ReadVolumesRequest{
 					Filters:        &osc.FiltersVolume{VolumeIds: &[]string{tc.volumeID}},
-					ResultsPerPage: ptr.To(1),
+					ResultsPerPage: new(1),
 				})).Return(&osc.ReadVolumesResponse{Volumes: &[]osc.Volume{vol}}, nil)
 			}
 			devicePath, err := c.AttachVolume(ctx, tc.volumeID, tc.nodeID)
@@ -456,7 +456,7 @@ func TestDetachVolume(t *testing.T) {
 					detached.LinkedVolumes = nil
 					mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Eq(osc.ReadVolumesRequest{
 						Filters:        &osc.FiltersVolume{VolumeIds: &[]string{tc.volumeID}},
-						ResultsPerPage: ptr.To(1),
+						ResultsPerPage: new(1),
 					})).Return(&osc.ReadVolumesResponse{Volumes: &[]osc.Volume{detached}}, nil)
 				}
 			}
@@ -504,7 +504,7 @@ func TestCheckCreatedVolume(t *testing.T) {
 			name:             "success: normal with snapshotId",
 			volumeName:       "vol-test-1234",
 			volumeCapacity:   util.GiBToBytes(1),
-			snapshotId:       ptr.To("snapshot-id123"),
+			snapshotId:       new("snapshot-id123"),
 			availabilityZone: expZone,
 			expErr:           nil,
 		},
@@ -584,7 +584,7 @@ func TestGetVolumeByID(t *testing.T) {
 		{
 			name:             "success: normal with snapshotId",
 			volumeID:         "vol-test-1234",
-			snapshotId:       ptr.To("snapshot-id123"),
+			snapshotId:       new("snapshot-id123"),
 			availabilityZone: expZone,
 			found:            true,
 		},
@@ -620,7 +620,7 @@ func TestGetVolumeByID(t *testing.T) {
 			}
 			mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Eq(osc.ReadVolumesRequest{
 				Filters:        &osc.FiltersVolume{VolumeIds: &[]string{tc.volumeID}},
-				ResultsPerPage: ptr.To(1),
+				ResultsPerPage: new(1),
 			})).Return(&res, nil)
 
 			vol, err := c.GetVolumeByID(ctx, tc.volumeID)
@@ -669,7 +669,7 @@ func TestCreateSnapshot(t *testing.T) {
 
 		mockOscInterface.EXPECT().CreateSnapshot(gomock.Any(), gomock.Eq(osc.CreateSnapshotRequest{
 			ClientToken: &snapName,
-			Description: ptr.To("Created by Outscale BSU CSI driver for volume " + volumeID),
+			Description: new("Created by Outscale BSU CSI driver for volume " + volumeID),
 			VolumeId:    &volumeID,
 		})).Return(&osc.CreateSnapshotResponse{
 			Snapshot: &inQueue,
@@ -680,7 +680,7 @@ func TestCreateSnapshot(t *testing.T) {
 		})).Return(&osc.CreateTagsResponse{}, nil)
 		q := osc.ReadSnapshotsRequest{
 			Filters:        &osc.FiltersSnapshot{SnapshotIds: &[]string{snapID}},
-			ResultsPerPage: ptr.To(1),
+			ResultsPerPage: new(1),
 		}
 		mockOscInterface.EXPECT().ReadSnapshots(gomock.Any(), gomock.Eq(q)).Return(&osc.ReadSnapshotsResponse{Snapshots: &[]osc.Snapshot{completed}}, nil).After(
 			mockOscInterface.EXPECT().ReadSnapshots(gomock.Any(), gomock.Eq(q)).Return(&osc.ReadSnapshotsResponse{Snapshots: &[]osc.Snapshot{pending}}, nil).After(
@@ -721,7 +721,7 @@ func TestCreateSnapshot(t *testing.T) {
 
 		mockOscInterface.EXPECT().CreateSnapshot(gomock.Any(), gomock.Eq(osc.CreateSnapshotRequest{
 			ClientToken: &snapName,
-			Description: ptr.To("Created by Outscale BSU CSI driver for volume " + volumeID),
+			Description: new("Created by Outscale BSU CSI driver for volume " + volumeID),
 			VolumeId:    &volumeID,
 		})).Return(&osc.CreateSnapshotResponse{
 			Snapshot: &firstSnap,
@@ -899,7 +899,7 @@ func TestGetSnapshotByID(t *testing.T) {
 			}
 			mockOscInterface.EXPECT().ReadSnapshots(gomock.Any(), gomock.Eq(osc.ReadSnapshotsRequest{
 				Filters:        &osc.FiltersSnapshot{SnapshotIds: &[]string{tc.snapshotID}},
-				ResultsPerPage: ptr.To(1),
+				ResultsPerPage: new(1),
 			})).Return(&res, nil)
 
 			_, err := c.GetSnapshotByID(ctx, tc.snapshotID)
@@ -997,7 +997,7 @@ func TestListSnapshots(t *testing.T) {
 			Filters: &osc.FiltersSnapshot{
 				TagKeys: &[]string{SnapshotNameTagKey},
 			},
-			ResultsPerPage: ptr.To(10),
+			ResultsPerPage: new(10),
 		})).Return(&osc.ReadSnapshotsResponse{Snapshots: &oscsnapshot}, nil)
 		_, err := c.ListSnapshots(ctx, "", 10, "")
 		require.NoError(t, err)
@@ -1041,7 +1041,7 @@ func TestListSnapshots(t *testing.T) {
 			Filters: &osc.FiltersSnapshot{
 				TagKeys: &[]string{SnapshotNameTagKey},
 			},
-			ResultsPerPage: ptr.To(1000),
+			ResultsPerPage: new(1000),
 		})).Return(&osc.ReadSnapshotsResponse{Snapshots: &oscsnapshot}, nil)
 		_, err := c.ListSnapshots(ctx, "", 2000, "")
 		require.NoError(t, err)
@@ -1085,8 +1085,8 @@ func TestListSnapshots(t *testing.T) {
 			Filters: &osc.FiltersSnapshot{
 				TagKeys: &[]string{SnapshotNameTagKey},
 			},
-			NextPageToken:  ptr.To("foo"),
-			ResultsPerPage: ptr.To(1000),
+			NextPageToken:  new("foo"),
+			ResultsPerPage: new(1000),
 		})).Return(&osc.ReadSnapshotsResponse{Snapshots: &oscsnapshot}, nil)
 		_, err := c.ListSnapshots(ctx, "", 0, "foo")
 		require.NoError(t, err)
@@ -1130,8 +1130,8 @@ func TestListSnapshots(t *testing.T) {
 			Filters: &osc.FiltersSnapshot{
 				TagKeys: &[]string{SnapshotNameTagKey},
 			},
-			NextPageToken:  ptr.To("foo"),
-			ResultsPerPage: ptr.To(10),
+			NextPageToken:  new("foo"),
+			ResultsPerPage: new(10),
 		})).Return(&osc.ReadSnapshotsResponse{Snapshots: &oscsnapshot}, nil)
 		_, err := c.ListSnapshots(ctx, "", 10, "foo")
 		require.NoError(t, err)

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -169,7 +169,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if sourceSnapshot == nil {
 			return nil, status.Error(codes.InvalidArgument, "Error retrieving snapshot from the volumeContentSource")
 		}
-		snapshotID = ptr.To(sourceSnapshot.GetSnapshotId())
+		snapshotID = new(sourceSnapshot.GetSnapshotId())
 	}
 
 	vol, err := d.cloud.CheckCreatedVolume(ctx, volName)

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/outscale/goutils/sdk/ptr"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/cloud"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/mocks"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/util"
@@ -107,7 +106,7 @@ func TestCreateVolume(t *testing.T) {
 			VolumeID:         req.Name,
 			AvailabilityZone: expZone,
 			CapacityGiB:      util.BytesToGiB(stdVolSize),
-			SnapshotID:       ptr.To("snapshot-id"),
+			SnapshotID:       new("snapshot-id"),
 		}
 
 		mockCtl := gomock.NewController(t)
@@ -153,7 +152,7 @@ func TestCreateVolume(t *testing.T) {
 			VolumeID:         req.Name,
 			AvailabilityZone: expZone,
 			CapacityGiB:      util.BytesToGiB(stdVolSize),
-			SnapshotID:       ptr.To("snapshot-id"),
+			SnapshotID:       new("snapshot-id"),
 		}
 
 		mockCtl := gomock.NewController(t)
@@ -198,7 +197,7 @@ func TestCreateVolume(t *testing.T) {
 			VolumeID:         req.Name,
 			AvailabilityZone: expZone,
 			CapacityGiB:      util.BytesToGiB(stdVolSize),
-			SnapshotID:       ptr.To("another-snapshot-id"),
+			SnapshotID:       new("another-snapshot-id"),
 		}
 
 		mockCtl := gomock.NewController(t)


### PR DESCRIPTION
## Description

This PR configures go.mod to use Go 1.26 and runs `go fix`.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
