### PR TITLE
🥅 fix: handle dual drivers edge cases

### DIFF
--- a/pkg/cloud/devicemanager/allocator.go
+++ b/pkg/cloud/devicemanager/allocator.go
@@ -37,12 +37,16 @@ var _ NameAllocator = &nameAllocator{}
 // GetNext gets next available device name.
 // This function iterates through the device names in deterministic order of:
 //
-//	b ... z, aa ... az
+//	b ... z, aa ... az, ba ... bz
 //
 // and return the first one that is not used yet.
 // Note: a is reserved for the root volume.
 func (d *nameAllocator) GetNext(existing []string) (string, error) {
-	deviceMap := [51]string{"b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai", "aj", "ak", "al", "am", "an", "ao", "ap", "aq", "ar", "as", "at", "au", "av", "aw", "ax", "ay", "az"}
+	deviceMap := [77]string{
+		"b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+		"aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai", "aj", "ak", "al", "am", "an", "ao", "ap", "aq", "ar", "as", "at", "au", "av", "aw", "ax", "ay", "az",
+		"ba", "bb", "bc", "bd", "be", "bf", "bg", "bh", "bi", "bj", "bk", "bl", "bm", "bn", "bo", "bp", "bq", "br", "bs", "bt", "bu", "bv", "bw", "bx", "by", "bz",
+	}
 	for _, name := range deviceMap {
 		if !slices.Contains(existing, name) {
 			return name, nil

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -18,6 +18,9 @@ package devicemanager
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNameAllocator(t *testing.T) {
@@ -29,12 +32,8 @@ func TestNameAllocator(t *testing.T) {
 		expectedName := expectedNames[i : i+1]
 		t.Run(expectedName, func(t *testing.T) {
 			actual, err := allocator.GetNext(existingNames)
-			if err != nil {
-				t.Errorf("test %q: unexpected error: %v", expectedName, err)
-			}
-			if actual != expectedName {
-				t.Errorf("test %q: expected %q, got %q", expectedName, expectedName, actual)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, expectedName, actual)
 			existingNames = append(existingNames, actual)
 		})
 	}
@@ -44,12 +43,11 @@ func TestNameAllocatorError(t *testing.T) {
 	allocator := nameAllocator{}
 	existingNames := []string{} //nolint
 
-	for range 52 {
-		name, _ := allocator.GetNext(existingNames)
+	for range 77 {
+		name, err := allocator.GetNext(existingNames)
+		require.NoError(t, err)
 		existingNames = append(existingNames, name)
 	}
 	name, err := allocator.GetNext(existingNames)
-	if err == nil {
-		t.Errorf("expected error, got device  %q", name)
-	}
+	require.Errorf(t, err, "expected error, got device %q", name)
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -605,6 +605,9 @@ func (s *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	if err != nil {
 		return nil, fmt.Errorf("compute limit: %w", err)
 	}
+	if maxVolumes <= 0 {
+		klog.FromContext(ctx).V(1).Info("Warning: unexpected MaxVolumesPerNode value", "MaxVolumesPerNode", maxVolumes)
+	}
 	return &csi.NodeGetInfoResponse{
 		NodeId:             s.instanceID,
 		MaxVolumesPerNode:  maxVolumes,
@@ -841,7 +844,7 @@ func (s *nodeService) getVolumesLimit(ctx context.Context) (int64, error) {
 
 	// devs includes the root volume
 	// we need to reserve getEnvReservedVolumes() + the root volume
-	maxVolumes = defaultMaxBSUVolumes - max(int64(volumes-pvcs), getEnvReservedVolumes()+1)
+	maxVolumes = max(0, defaultMaxBSUVolumes-max(int64(volumes-pvcs), getEnvReservedVolumes()+1))
 	logger.V(3).Info("Computed limit", "maxVolumes", maxVolumes)
 	return maxVolumes, nil
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1672,6 +1672,17 @@ func TestNodeGetInfo(t *testing.T) {
 			expMaxVolumes: 37,
 		},
 		{
+			name:         "1 OS mounted volume, no PVC, 45 reserved",
+			instanceID:   "i-123456789abcdef01",
+			instanceType: "tinav6.c1r6p2",
+			subRegion:    "us-west-2b",
+			envReserved:  "45",
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
+			},
+			expMaxVolumes: 0,
+		},
+		{
 			name:         "1 OS mounted volume on xvdb, 1 PVC on xvdc",
 			instanceID:   "i-123456789abcdef01",
 			instanceType: "tinav6.c1r6p2",


### PR DESCRIPTION
## Description

When 2 CSI drivers are installed (each with its own identity), there might be cases when the CSI subsystem will try to allocate more than 39 volumes on a node.

This PR:
- increases the size of the list of possible device names, to avoid "there are no names available" errors
- ensures that NodeGetInfo returns a value of MaxVolumesPerNode that is above 0

A 0 MaxVolumesPerNode value is interpreted by the CSI as "allocate as you wish", not "do not allocate". A warning is logged if the value is 0 or less.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): edge cases handling

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
